### PR TITLE
Support title format modifications

### DIFF
--- a/doc/moloch.tex
+++ b/doc/moloch.tex
@@ -166,10 +166,10 @@ The following code shows a minimal example of a Beamer presentation using
 \begin{lstlisting}
 \documentclass{beamer}
 \usetheme{moloch}
-\title{A minimal example}
+\title{A Minimal Example}
 \date{\today}
 \author{Johan Larsson}
-\institute{Centre for Modern Beamer Themes}
+\institute{Some University}
 \begin{document}
   \maketitle
   \section{First Section}

--- a/doc/moloch.tex
+++ b/doc/moloch.tex
@@ -412,7 +412,7 @@ solution for Org mode users, using |org-set-property|.
 
 \subsection{Standout frames with Pandoc}
 
-With Pandoc versions prior 1.17.2 it was not possible to create standout frames
+With Pandoc versions prior to 1.17.2 it was not possible to create standout frames
 because Pandoc only supported a specific list of frame attributes thus ignoring
 additional attributes such as  |{.standout}|.
 

--- a/doc/moloch.tex
+++ b/doc/moloch.tex
@@ -58,7 +58,7 @@
   xrightmargin=0em,
   aboveskip=1em,
   belowskip=1em,
-  morekeywords={usetheme,institute,maketitle,%
+  morekeywords={usetheme,institute,maketitle,@moloch@titleformat,%
                 plain,setbeamercolor,molochset,setsansfont,setmonofont},
 }
 \lstMakeShortInline|
@@ -187,6 +187,7 @@ The following code shows a minimal example of a Beamer presentation using
   \begin{itemize}
     \item |tikz|
     \item |pgfopts|
+    \item |etoolbox|
     \item |calc|
   \end{itemize}
 \end{multicols}
@@ -223,6 +224,27 @@ The list of options is structured as shown in the following example.
 \DescribeOption{option key}{list of possible values}{default}{
   A short description of the option.
 }
+
+
+\subsubsection{Main theme}
+
+\DescribeOption{titleformat}%
+{regular, smallcaps, allsmallcaps, allcaps}
+{regular}{
+  Changes the format of titles, subtitles, section titles, frame titles, and
+  the text on ``standout'' frames. The available options produce
+  Regular, \textsc{SmallCaps}, \textsc{\MakeLowercase{AllSmallCaps}}, or
+  \MakeUppercase{AllCaps} titles. Note that these commands do not
+  affect math and numbers, so may not work as you expect if your titles
+  contain these.
+}
+
+\DescribeOption{titleformat plain}%
+{regular, smallcaps, allsmallcaps, allcaps}%
+{regular}{
+  Changes the format of ``standout'' frames (see |titleformat|, above).
+}
+
 
 \subsubsection{Inner theme}
 
@@ -269,6 +291,20 @@ The list of options is structured as shown in the following example.
   Provides the option to have a dark background and light foreground instead
   of the reverse.
 }
+
+
+\subsubsection{Font theme}
+
+\DescribeMacro{titleformat title}
+\DescribeMacro{titleformat subtitle}
+\DescribeMacro{titleformat section}
+\DescribeOption{titleformat frame}%
+{regular, smallcaps, allsmallcaps, allcaps}%
+{regular}{
+  Individually controls the format of titles, subtitles, section titles, and
+  frame titles (see |titleformat|, above).
+}
+
 
 \subsection{Color Customization}
 
@@ -320,6 +356,18 @@ single sentence or image. To use it, add the key |standout| to the frame:
 \end{lstlisting}
 
 \section{Known Issues}
+
+\subsection{Title Formats}
+
+Be aware that not every font supports small caps, so the |smallcaps| or
+|allsmallcaps| options may not work for all fonts.
+In particular, the Computer Modern sans-serif typeface, which is used
+by default when \themename is compiled with pdf\LaTeX, does not have a
+small-caps variant.
+
+Note that title format options |allsmallcaps| and |allcaps| do not 
+affect the sizes of numerals, punctuation, and math symbol, and are 
+probably best avoided if your titles contain these characters.
 
 \subsection{Interactions with other color themes}
 

--- a/examples/demo/demo.tex
+++ b/examples/demo/demo.tex
@@ -95,7 +95,7 @@
 
     \column{0.33\textwidth}
     Descriptions
-    \begin{description}
+    \begin{description}[PowerPoint]
       \item[PowerPoint] Meeh. \item[Beamer] Yeeeha.
     \end{description}
   \end{columns}

--- a/examples/demo/demo.tex
+++ b/examples/demo/demo.tex
@@ -12,7 +12,7 @@
 \usepackage{booktabs}
 \usepackage[scale=2]{ccicons}
 
-\usepackage{lmodern}
+\usepackage[semibold,light]{FiraSans}
 
 \usepackage{xspace}
 
@@ -38,8 +38,9 @@
 \begin{frame}[fragile]{Moloch}
 
   The \themename theme is a Beamer theme with minimal visual noise. It is a fork of the
-  \href{https://github.com/matze/mtheme}{metropolis theme} by Matthias Vogelgesang, which in turn was inspired by
-  by the \href{https://github.com/hsrmbeamertheme/hsrmbeamertheme}{hsrm theme} by Benjamin Weiss. \medskip
+  \href{https://github.com/matze/mtheme}{metropolis theme} by Matthias Vogelgesang, which in
+  turn was inspired by by the \href{https://github.com/hsrmbeamertheme/hsrmbeamertheme}{hsrm
+    theme} by Benjamin Weiss. \medskip
 
   Enable the theme by calling
   \begin{verbatim}\documentclass{beamer}
@@ -48,8 +49,69 @@
 \begin{frame}[fragile]{Sections}
   Sections group slides of the same topic by introducing a section page between them. A progress bar is shown which indicates how far along in the presentation you are.
 
-  \begin{verbatim}\section{Elements}\end{verbatim}
+  \begin{verbatim}\section{Title Formats}\end{verbatim}
 \end{frame}
+
+\section{Title Formats}
+
+\begin{frame}[fragile]{Moloch Title Formats}
+  \themename supports four different title formats:
+  \begin{itemize}
+    \item \texttt{regular} (Regular)
+    \item \texttt{smallcaps} (\textsc{Small Caps})
+    \item \texttt{allsmallcaps} (\textsc{all small caps})
+    \item \texttt{allcaps} (ALL CAPS)
+  \end{itemize}
+
+  They can either be set globally for every frame or used locally just for the current frame
+  and onwards by using
+  \begin{verbatim}\molochset{titleformat frame=<option>}\end{verbatim}
+\end{frame}
+
+{
+\molochset{titleformat frame=smallcaps}
+\begin{frame}{Small Caps}
+  This frame uses the \texttt{smallcaps} title format.
+
+  \begin{alertblock}{Potential Problems}
+    Be aware that not every font supports small caps. If you use the Computer (or Latin) Modern Sans Serif font, for instance, text in small caps will just be typeset in a normal font.
+  \end{alertblock}
+\end{frame}
+}
+
+{
+\molochset{titleformat frame=allsmallcaps}
+\begin{frame}{All Small Caps}
+  This frame uses the \texttt{allsmallcaps} title format.
+
+  \begin{alertblock}{Potential Problems}
+    This title format also uses small caps, so you face the same problems as with the \texttt{smallcaps} title format.
+
+    \medskip
+
+    In addition, note that numbers and math will be unaffected by this setting and will match
+    poorly with text as a result. For that reason, we suggest you make sure titles are all
+    plain text if you use this option.
+
+    \medskip
+
+    Finally, observe that the height of the frame title box will be modified to account for the
+    decreased text height since there are no capital letters. This too means that numbers and
+    math will not work well.
+  \end{alertblock}
+\end{frame}
+}
+
+{
+\molochset{titleformat frame=allcaps}
+\begin{frame}{All Caps}
+  This frame uses the \texttt{allcaps} title format.
+
+  \begin{alertblock}{Potential Problems}
+    This title format is not as problematic as the \texttt{allsmallcaps} format, but basically suffers from the same deficiencies. So please have a look at the documentation if you want to use it.
+  \end{alertblock}
+\end{frame}
+}
 
 \section{Elements}
 
@@ -223,7 +285,8 @@
   \end{center}
 
   The theme is licensed under the
-  \href{http://creativecommons.org/licenses/by-sa/4.0/}{Creative Commons Attribution-ShareAlike 4.0 International License}.
+  \href{http://creativecommons.org/licenses/by-sa/4.0/}{Creative Commons
+    Attribution-ShareAlike 4.0 International License}.
 
   \begin{center}
     \ccbysa

--- a/src/beamerfontthememoloch.dtx
+++ b/src/beamerfontthememoloch.dtx
@@ -27,9 +27,12 @@
 %
 % A |beamer| font theme sets the style of the font used in the document.
 %
+%
+%
 % \subsubsection{Package dependencies}
 %
 %    \begin{macrocode}
+\RequirePackage{etoolbox}
 \RequirePackage{pgfopts}
 %    \end{macrocode}
 %
@@ -51,6 +54,188 @@
 \setbeamerfont{standout}{size=\Large, series=\bfseries}
 %    \end{macrocode}
 %
+%
+%
+% \subsubsection{Title format options}
+%
+% \begin{macro}{titleformat title}
+%    Controls the format of the title.
+%    \begin{macrocode}
+\pgfkeys{
+  /moloch/font/titleformat title/.cd,
+  .is choice,
+  regular/.code={%
+      \let\moloch@titleformat\@empty%
+      \setbeamerfont{title}{shape=\normalfont}%
+    },
+  smallcaps/.code={%
+      \let\moloch@titleformat\@empty%
+      \setbeamerfont{title}{shape=\scshape}%
+    },
+  allsmallcaps/.code={%
+      \let\moloch@titleformat\lowercase%
+      \setbeamerfont{title}{shape=\scshape}%
+      \PackageNote{beamerthememoloch}{%
+        Be aware that titleformat title=allsmallcaps can lead to problems%
+      }
+    },
+  allcaps/.code={%
+      \let\moloch@titleformat\uppercase%
+      \setbeamerfont{title}{shape=\normalfont}
+      \PackageNote{beamerthememoloch}{%
+        Be aware that titleformat title=allcaps can lead to problems%
+      }
+    },
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{titleformat subtitle}
+%    Control the format of the subtitle.
+%    \begin{macrocode}
+\pgfkeys{
+  /moloch/font/titleformat subtitle/.cd,
+  .is choice,
+  regular/.code={%
+      \let\moloch@subtitleformat\@empty%
+      \setbeamerfont{subtitle}{shape=\normalfont}%
+    },
+  smallcaps/.code={%
+      \let\moloch@subtitleformat\@empty%
+      \setbeamerfont{subtitle}{shape=\scshape}%
+    },
+  allsmallcaps/.code={%
+      \let\moloch@subtitleformat\MakeLowercase%
+      \setbeamerfont{subtitle}{shape=\scshape}%
+      \PackageNote{beamerthememoloch}{%
+        Be aware that titleformat subtitle=allsmallcaps can lead to problems%
+      }
+    },
+  allcaps/.code={%
+      \let\moloch@subtitleformat\MakeUppercase%
+      \setbeamerfont{subtitle}{shape=\normalfont}%
+      \PackageNote{beamerthememoloch}{%
+        Be aware that titleformat subtitle=allcaps can lead to problems%
+      }
+    },
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{titleformat section}
+%    Controls the format of the section title.
+%    \begin{macrocode}
+\pgfkeys{
+  /moloch/font/titleformat section/.cd,
+  .is choice,
+  regular/.code={%
+      \let\moloch@sectiontitleformat\@empty%
+      \setbeamerfont{section title}{shape=\normalfont}%
+    },
+  smallcaps/.code={%
+      \let\moloch@sectiontitleformat\@empty%
+      \setbeamerfont{section title}{shape=\scshape}%
+    },
+  allsmallcaps/.code={%
+      \let\moloch@sectiontitleformat\MakeLowercase%
+      \setbeamerfont{section title}{shape=\scshape}%
+      \PackageNote{beamerthememoloch}{%
+        Be aware that titleformat section=allsmallcaps can lead to problems%
+      }
+    },
+  allcaps/.code={%
+      \let\moloch@sectiontitleformat\MakeUppercase%
+      \setbeamerfont{section title}{shape=\normalfont}%
+      \PackageNote{beamerthememoloch}{%
+        Be aware that titleformat section=allcaps can lead to problems%
+      }
+    },
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{frametitleformat}
+%    Control the format of the frame title.
+%    \begin{macrocode}
+\pgfkeys{
+  /moloch/font/titleformat frame/.cd,
+  .is choice,
+  regular/.code={%
+      \let\moloch@frametitleformat\@empty%
+      \setbeamerfont{frametitle}{shape=\normalfont}%
+    },
+  smallcaps/.code={%
+      \let\moloch@frametitleformat\@empty%
+      \setbeamerfont{frametitle}{shape=\scshape}%
+    },
+  allsmallcaps/.code={%
+      \let\moloch@frametitleformat\MakeLowercase%
+      \setbeamerfont{frametitle}{shape=\scshape}%
+      \PackageNote{beamerthememoloch}{%
+        Be aware that titleformat frame=allsmallcaps can lead to problems%
+      }
+    },
+  allcaps/.code={%
+      \let\moloch@frametitleformat\MakeUppercase%
+      \setbeamerfont{frametitle}{shape=\normalfont}
+      \PackageNote{beamerthememoloch}{%
+        Be aware that titleformat frame=allcaps can lead to problems%
+      }
+    },
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{titleformat aliases}
+%    Allows |titleformat title| et al. to be used in the |\usetheme|
+%    declaration, where \LaTeX{} automatically removes all spaces.
+%    \begin{macrocode}
+\pgfkeys{
+  /moloch/font/.cd,
+  titleformattitle/.code=\pgfkeysalso{titleformat title=#1},
+  titleformatsubtitle/.code=\pgfkeysalso{titleformat subtitle=#1},
+  titleformatsection/.code=\pgfkeysalso{titleformat section=#1},
+  titleformatframe/.code=\pgfkeysalso{titleformat frame=#1},
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\moloch@font@setdefaults}
+%    Sets default values for font theme options.
+%    \begin{macrocode}
+\newcommand{\moloch@font@setdefaults}{
+  \pgfkeys{/moloch/font/.cd,
+    titleformat title=regular,
+    titleformat subtitle=regular,
+    titleformat section=regular,
+    titleformat frame=regular,
+  }
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% We first define hooks to change the case format of the titles.
+%
+%    \begin{macrocode}
+\def\moloch@titleformat#1{#1}
+\def\moloch@subtitleformat#1{#1}
+\def\moloch@sectiontitleformat#1{#1}
+\def\moloch@frametitleformat#1{#1}
+%    \end{macrocode}
+%
+% To make the uppercase and lowercase macros work in the title, subtitle, etc.,
+% we have to patch the appropriate |beamer| commands that set their values.
+% This solution was suggested by Enrico Gregorio in an answer to
+% \href{http://tex.stackexchange.com/questions/112526/}{this StackExchange
+% question}.
+%
+%
+% \subsubsection{Process package options}
+%
+%    \begin{macrocode}
+\moloch@font@setdefaults
+\ProcessPgfPackageOptions{/moloch/font}
+%    \end{macrocode}
 % \iffalse
 %</package>
 % \fi

--- a/src/beamerinnerthememoloch.dtx
+++ b/src/beamerinnerthememoloch.dtx
@@ -173,7 +173,7 @@
 %    \begin{macrocode}
 \setbeamertemplate{title}{
   \raggedright%
-  \inserttitle%
+  \moloch@titleformat{\inserttitle}%
   \par%
   \vspace*{0.2em}
 }
@@ -186,7 +186,7 @@
 \setbeamertemplate{subtitle}{
   \vspace*{0.1em}
   \raggedright%
-  \insertsubtitle%
+  \moloch@subtitleformat{\insertsubtitle}%
   \par%
   \vspace*{0.2em}
 }
@@ -258,7 +258,7 @@
   \begin{center}
     \usebeamercolor[fg]{section title}
     \usebeamerfont{section title}
-    \insertsectionhead\par
+    \moloch@sectiontitleformat{\insertsectionhead}\par
     \ifx\insertsubsectionhead\@empty\else
       \usebeamercolor[fg]{subsection title}
       \usebeamerfont{subsection title}
@@ -272,7 +272,7 @@
     \raggedright
     \usebeamercolor[fg]{section title}
     \usebeamerfont{section title}
-    \insertsectionhead\\[-1ex]
+    \moloch@sectiontitleformat{\insertsectionhead}\\[-1ex]
     \usebeamertemplate*{progress bar in section page}
     \par
     \ifx\insertsubsectionhead\@empty\else%

--- a/src/beamerouterthememoloch.dtx
+++ b/src/beamerouterthememoloch.dtx
@@ -160,23 +160,42 @@
 %    Templates for the frame title, which is optionally underlined with a
 %    progress bar.
 %    \begin{macrocode}
+\newlength{\moloch@frametitle@padding}
+\setlength{\moloch@frametitle@padding}{2.2ex}
+\newcommand{\moloch@frametitlestrut@start}{%
+  \rule{0pt}{\moloch@frametitle@padding +%
+    \totalheightof{%
+      \ifcsdef{moloch@frametitleformat}{\moloch@frametitleformat X}{X}%
+    }%
+}%
+}
+
+\newcommand{\moloch@frametitlestrut@end}{%
+  \vphantom{\rule[-\moloch@frametitle@padding]{0pt}{\moloch@frametitle@padding}}
+}
 \defbeamertemplate{frametitle}{plain}{%
   \nointerlineskip%
   \begin{beamercolorbox}[%
       wd=\paperwidth,%
-      sep=1.1ex,%
-      leftskip=0.5ex,%
-      rightskip=\the\glueexpr 0.5ex plus 1fill\relax,%
+      leftskip=1.6ex,%
+      rightskip=\the\glueexpr 1.6ex plus 1fill\relax,%
     ]{frametitle}%
     \usebeamerfont{frametitle}%
-    \vbox{}\vskip-0.4ex%
-    \strut\insertframetitle\nolinebreak\strut\par%
+    \moloch@frametitlestrut@start%
+    \moloch@frametitleformat{\insertframetitle}%
     {%
       \ifx\insertframesubtitle\@empty%
         \else%
-        {\usebeamerfont{framesubtitle}\vspace{-0.8ex}\usebeamercolor[fg]{framesubtitle}\strut\insertframesubtitle\strut\par}%
+        {%
+          \par%
+          \usebeamerfont{framesubtitle}%
+          \vspace{-0.8ex}%
+          \usebeamercolor[fg]{framesubtitle}%
+          \insertframesubtitle%
+        }%
       \fi
     }%
+    \moloch@frametitlestrut@end%
   \end{beamercolorbox}%
 }
 \setbeamertemplate{frametitle continuation}{\romannumeral\insertcontinuationcount}

--- a/src/beamerthememoloch.dtx
+++ b/src/beamerthememoloch.dtx
@@ -52,6 +52,58 @@
 }
 %    \end{macrocode}
 %
+% \begin{macro}{titleformat plain}
+%    Controls the formatting of the text on standout ``plain'' frames.
+%    \begin{macrocode}
+\pgfkeys{
+  /moloch/titleformat plain/.cd,
+  .is choice,
+  regular/.code={%
+      \let\moloch@plaintitleformat\@empty%
+      \setbeamerfont{standout}{shape=\normalfont}%
+    },
+  smallcaps/.code={%
+      \let\moloch@plaintitleformat\@empty%
+      \setbeamerfont{standout}{shape=\scshape}%
+    },
+  allsmallcaps/.code={%
+      \let\moloch@plaintitleformat\MakeLowercase%
+      \setbeamerfont{standout}{shape=\scshape}%
+    },
+  allcaps/.code={%
+      \let\moloch@plaintitleformat\MakeUppercase%
+      \setbeamerfont{standout}{shape=\normalfont}%
+    },
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{titleformat}
+%    Sets a standard format for titles, subtitles, section titles, frame
+%    titles, and the text on standout ``plain'' frames.
+%    \begin{macrocode}
+\pgfkeys{
+  /moloch/titleformat/.code=\pgfkeysalso{
+    font/titleformat title=#1,
+    font/titleformat subtitle=#1,
+    font/titleformat section=#1,
+    font/titleformat frame=#1,
+    titleformat plain=#1,
+  }
+}
+%    \end{macrocode}
+% \end{macro}
+%
+% Set default values for options.
+%
+%    \begin{macrocode}
+\newcommand{\moloch@setdefaults}{
+  \pgfkeys{/moloch/.cd,
+    titleformat plain=regular,
+  }
+}
+%    \end{macrocode}
+%
 % To avoid generating externalized figures of the progressbar we have to disable
 % them with ``tikzexternalenable'' and ``tikzexternaldisable''. However, if the
 % ``external'' libray is not loaded we would get undefined control sequence
@@ -101,6 +153,7 @@
 % \subsubsection{Process package options}
 %
 %    \begin{macrocode}
+\moloch@setdefaults
 \ProcessPgfOptions{/moloch}
 %    \end{macrocode}
 %

--- a/testfiles/support/molochexample.tex
+++ b/testfiles/support/molochexample.tex
@@ -41,6 +41,39 @@
 \vfil\break
 \END
 
+{
+  \molochset{titleformat frame=smallcaps}
+  \begin{frame}{Small caps}
+    This frame uses the \texttt{smallcaps} title format.
+
+    \begin{block}{Block}
+      Some content
+    \end{block}
+
+    \begin{alertblock}{Alert Block}
+      Yet more content
+    \end{alertblock}
+
+    \begin{exampleblock}{Example Block}
+      Just to try out the different blocks
+    \end{exampleblock}
+  \end{frame}
+}
+
+{
+  \molochset{titleformat frame=allsmallcaps}
+  \begin{frame}{All small caps}
+    This frame uses the \texttt{allsmallcaps} title format.
+  \end{frame}
+}
+
+{
+  \molochset{titleformat frame=allcaps}
+  \begin{frame}{All caps}
+    This frame uses the \texttt{allcaps} title format.
+  \end{frame}
+}
+
 \begin{frame}{Lists}
   \begin{columns}[T,onlytextwidth]
     \column{0.33\textwidth}

--- a/testfiles/test.tlg
+++ b/testfiles/test.tlg
@@ -131,7 +131,7 @@ Completed box being shipped out [1]
 ....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ....\glue(\topskip) 0.0
-....\vbox(261.20912+0.0)x307.28987, glue set 78.61551fill
+....\vbox(261.20912+0.0)x307.28987, glue set 78.06667fill
 .....\penalty 10000
 .....\vbox(0.0+0.0)x0.0
 .....\penalty 10000
@@ -140,41 +140,28 @@ Completed box being shipped out [1]
 .....\vbox(0.0+0.0)x0.0
 .....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .....\pdfcolorstack 0 push {0.98 g 0.98 G}
-.....\hbox(28.1001+0.0)x307.28987, glue set - 1.0
+.....\hbox(19.04002+10.70662)x307.28987, glue set - 1.0
 ......\glue 0.0 minus 28.45274
-......\hbox(28.1001+0.0)x364.19536
+......\hbox(19.04002+10.70662)x364.19536
 .......\glue 0.0
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-.......\hbox(28.1001+0.0)x0.0, glue set - 364.19536fil
-........\rule(28.1001+0.0)x364.19536
+.......\hbox(19.04002+10.70662)x0.0, glue set - 364.19536fil
+........\rule(19.04002+10.70662)x364.19536
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 .......\pdfcolorstack 0 pop
-.......\hbox(28.1001+0.0)x364.19536
+.......\hbox(19.04002+10.70662)x364.19536
 ........\kern 0.0
 ........\pdfcolorstack 0 push {0.98 g 0.98 G}
 ........\glue 0.0
-........\hbox(28.1001+0.0)x364.19536
+........\hbox(19.04002+10.70662)x364.19536
 .........\pdfcolorstack 0 push {0.98 g 0.98 G}
-.........\vbox(28.1001+0.0)x364.19536
-..........\glue 6.05
-..........\glue(\parskip) 0.0
-..........\glue(\parskip) 0.0
-..........\hbox(0.0+0.0)x364.19536, glue set 346.59538fill
-...........\glue(\leftskip) 8.79999
+.........\vbox(19.04002+10.70662)x364.19536
+..........\hbox(19.04002+10.70662)x364.19536, glue set 250.40332fill
+...........\glue(\leftskip) 8.8
 ...........\hbox(0.0+0.0)x0.0
-...........\vbox(0.0+0.0)x0.0
-...........\penalty 10000
-...........\glue(\parfillskip) 0.0 plus 1.0fil
-...........\glue(\rightskip) 8.79999 plus 1.0fill
-..........\glue -2.19995
-..........\glue(\parskip) 0.0
-..........\glue(\parskip) 0.0
-..........\glue(\baselineskip) 4.20004
-..........\hbox(9.79996+4.20004)x364.19536, glue set 250.40335fill
-...........\glue(\leftskip) 8.79999
-...........\hbox(0.0+0.0)x0.0
-...........\rule(9.79996+4.20004)x0.0
+...........\hbox(19.04002+0.0)x0.0
+............\rule(19.04002+0.0)x0.0
 ...........\OT1/lmss/bx/n/12 T
 ...........\kern-1.1
 ...........\OT1/lmss/bx/n/12 a
@@ -193,12 +180,10 @@ Completed box being shipped out [1]
 ...........\OT1/lmss/bx/n/12 n
 ...........\OT1/lmss/bx/n/12 t
 ...........\OT1/lmss/bx/n/12 s
-...........\penalty 10000
-...........\rule(9.79996+4.20004)x0.0
+...........\hbox(0.0+10.70662)x0.0
 ...........\penalty 10000
 ...........\glue(\parfillskip) 0.0 plus 1.0fil
-...........\glue(\rightskip) 8.79999 plus 1.0fill
-..........\glue 6.05
+...........\glue(\rightskip) 8.8 plus 1.0fill
 .........\pdfcolorstack 0 pop
 ........\glue 0.0
 ........\pdfcolorstack 0 pop
@@ -621,7 +606,7 @@ Completed box being shipped out [3]
 ....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@subsectionpages {2}{2}}}}
 ....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@subsectionentry {0}{1}{1}{3}{Proof of the Main Theorem}}}}
 ....\glue(\topskip) 0.0
-....\vbox(261.20912+0.0)x307.28987, glue set 45.46286fill
+....\vbox(261.20912+0.0)x307.28987, glue set 44.13959fill
 .....\penalty 10000
 .....\vbox(0.0+0.0)x0.0
 .....\penalty 10000
@@ -630,41 +615,28 @@ Completed box being shipped out [3]
 .....\vbox(0.0+0.0)x0.0
 .....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .....\pdfcolorstack 0 push {0.98 g 0.98 G}
-.....\hbox(37.43343+0.0)x307.28987, glue set - 1.0
+.....\hbox(29.37335+10.70662)x307.28987, glue set - 1.0
 ......\glue 0.0 minus 28.45274
-......\hbox(37.43343+0.0)x364.19536
+......\hbox(29.37335+10.70662)x364.19536
 .......\glue 0.0
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-.......\hbox(37.43343+0.0)x0.0, glue set - 364.19536fil
-........\rule(37.43343+0.0)x364.19536
+.......\hbox(29.37335+10.70662)x0.0, glue set - 364.19536fil
+........\rule(29.37335+10.70662)x364.19536
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 .......\pdfcolorstack 0 pop
-.......\hbox(37.43343+0.0)x364.19536
+.......\hbox(29.37335+10.70662)x364.19536
 ........\kern 0.0
 ........\pdfcolorstack 0 push {0.98 g 0.98 G}
 ........\glue 0.0
-........\hbox(37.43343+0.0)x364.19536
+........\hbox(29.37335+10.70662)x364.19536
 .........\pdfcolorstack 0 push {0.98 g 0.98 G}
-.........\vbox(37.43343+0.0)x364.19536
-..........\glue 6.05
-..........\glue(\parskip) 0.0
-..........\glue(\parskip) 0.0
-..........\hbox(0.0+0.0)x364.19536, glue set 346.59538fill
-...........\glue(\leftskip) 8.79999
+.........\vbox(29.37335+10.70662)x364.19536
+..........\hbox(19.04002+2.33331)x364.19536, glue set 150.29268fill
+...........\glue(\leftskip) 8.8
 ...........\hbox(0.0+0.0)x0.0
-...........\vbox(0.0+0.0)x0.0
-...........\penalty 10000
-...........\glue(\parfillskip) 0.0 plus 1.0fil
-...........\glue(\rightskip) 8.79999 plus 1.0fill
-..........\glue -2.19995
-..........\glue(\parskip) 0.0
-..........\glue(\parskip) 0.0
-..........\glue(\baselineskip) 4.20004
-..........\hbox(9.79996+4.20004)x364.19536, glue set 150.29271fill
-...........\glue(\leftskip) 8.79999
-...........\hbox(0.0+0.0)x0.0
-...........\rule(9.79996+4.20004)x0.0
+...........\hbox(19.04002+0.0)x0.0
+............\rule(19.04002+0.0)x0.0
 ...........\OT1/lmss/bx/n/12 T
 ...........\OT1/lmss/bx/n/12 h
 ...........\OT1/lmss/bx/n/12 e
@@ -700,20 +672,17 @@ Completed box being shipped out [3]
 ...........\OT1/lmss/bx/n/12 e
 ...........\OT1/lmss/bx/n/12 r
 ...........\penalty 10000
-...........\rule(9.79996+4.20004)x0.0
-...........\penalty 10000
 ...........\glue(\parfillskip) 0.0 plus 1.0fil
-...........\glue(\rightskip) 8.79999 plus 1.0fill
+...........\glue(\rightskip) 8.8 plus 1.0fill
 ..........\glue -3.66667
 ..........\glue 0.0
 ..........\pdfcolorstack 0 push {0.98 g 0.98 G}
 ..........\glue(\parskip) 0.0
 ..........\glue(\parskip) 0.0
-..........\glue(\lineskip) 1.0
-..........\hbox(8.39996+3.60004)x364.19536, glue set 172.10007fill
-...........\glue(\leftskip) 8.79999
+..........\glue(\baselineskip) 4.72218
+..........\hbox(6.9445+10.70662)x364.19536, glue set 172.10004fill
+...........\glue(\leftskip) 8.8
 ...........\hbox(0.0+0.0)x0.0
-...........\rule(8.39996+3.60004)x0.0
 ...........\OT1/lmss/bx/n/10 T
 ...........\OT1/lmss/bx/n/10 h
 ...........\OT1/lmss/bx/n/10 e
@@ -752,12 +721,11 @@ Completed box being shipped out [3]
 ...........\OT1/lmss/bx/sl/10 u
 ...........\OT1/lmss/bx/sl/10 m
 ...........\OT1/lmss/bx/n/10 .
-...........\rule(8.39996+3.60004)x0.0
+...........\pdfcolorstack 0 pop
+...........\hbox(0.0+10.70662)x0.0
 ...........\penalty 10000
 ...........\glue(\parfillskip) 0.0 plus 1.0fil
-...........\glue(\rightskip) 8.79999 plus 1.0fill
-..........\pdfcolorstack 0 pop
-..........\glue 6.05
+...........\glue(\rightskip) 8.8 plus 1.0fill
 .........\pdfcolorstack 0 pop
 ........\glue 0.0
 ........\pdfcolorstack 0 pop


### PR DESCRIPTION
Fixes #17. This pull requests brings back support for title format modifications that were previously removed since they patched beamer commands, which I want to avoid. Many of the problems that were listed as issues in the metropolis documentation seem to have magically disappeared also, so the options now seem much more robust.

This PR also includes a small modification to the titleformat spacing, but it should hardly be noticeable.

Everything seems to be working fine for me, but I would appreciate help to bug test this.