### PR TITLE
switch from fill to fil

### DIFF
--- a/src/beamerinnerthememoloch.dtx
+++ b/src/beamerinnerthememoloch.dtx
@@ -409,8 +409,8 @@
 %
 %    \begin{macrocode}
 \define@key{beamerframe}{c}[true]{% centered
-  \beamer@frametopskip=0pt plus 1fill\relax%
-  \beamer@framebottomskip=0pt plus 1fill\relax%
+  \beamer@frametopskip=0pt plus 1fil\relax%
+  \beamer@framebottomskip=0pt plus 1fil\relax%
   \beamer@frametopskipautobreak=0pt plus .4\paperheight\relax%
   \beamer@framebottomskipautobreak=0pt plus .6\paperheight\relax%
   \def\beamer@initfirstlineunskip{}%

--- a/src/beamerouterthememoloch.dtx
+++ b/src/beamerouterthememoloch.dtx
@@ -178,7 +178,7 @@
   \begin{beamercolorbox}[%
       wd=\paperwidth,%
       leftskip=1.6ex,%
-      rightskip=\the\glueexpr 1.6ex plus 1fill\relax,%
+      rightskip=\the\glueexpr 1.6ex plus 1fil\relax,%
     ]{frametitle}%
     \usebeamerfont{frametitle}%
     \moloch@frametitlestrut@start%


### PR DESCRIPTION
First of all - thanks for maintaining this. 

I faced a small issue: When using `\hfill` inside the `frametitle` it will not be shifted to the right as the right skip uses `1fill` to fill the line.

Not sure if you are aware, but one can easily fix that by using `1fil` which actually does the same but is less strong. So if we have `1fill` and `1fil` the one with 2 “l” will win. 

I also saw you did the same vertically and there it's the same as end users usually just use `\hfill`/`\vfill` it would be great if you could change that. Hope the explanation is enough to get my points, otherwhise feel free to ask.