### PR TITLE
fix: remove duplicated footnote color specifications

### DIFF
--- a/src/beamercolorthememoloch.dtx
+++ b/src/beamercolorthememoloch.dtx
@@ -223,14 +223,6 @@
 \setbeamercolor{footnote mark}{fg=.}
 %    \end{macrocode}
 %
-%
-% Footnotes
-%
-%    \begin{macrocode}
-\setbeamercolor{footnote}{fg=normal text.fg!90}
-\setbeamercolor{footnote mark}{fg=.}
-%    \end{macrocode}
-%
 % We also reset the bibliography colors in order to pick up the surrounding
 % colors at the time of use. This prevents us having to set the correct color in
 % normal and standout mode.


### PR DESCRIPTION
bf63dcd duplicated the existing footnote color specifications.