### PR TITLE
fix: remove extra space below progressbar on section pages

### DIFF
--- a/src/beamerinnerthememoloch.dtx
+++ b/src/beamerinnerthememoloch.dtx
@@ -352,7 +352,7 @@
     (0,0)
     rectangle
     (\moloch@progressonsectionpage, \moloch@progressonsectionpage@linewidth);
-  \end{tikzpicture}
+  \end{tikzpicture}%
   \tikzexternalenable%
 }
 %    \end{macrocode}


### PR DESCRIPTION
The missing trailing comment after the Metropolis conversion was adding extraneous vertical space below the progress bar on section pages.