### PR TITLE
feat: vertically centre progressbar section title on baseline 

### DIFF
--- a/src/beamerinnerthememoloch.dtx
+++ b/src/beamerinnerthememoloch.dtx
@@ -269,6 +269,8 @@
 \defbeamertemplate{section page}{progressbar}{
   \centering
   \begin{minipage}{0.7875\linewidth}
+    \null%
+    \vfil%
     \raggedright
     \usebeamercolor[fg]{section title}
     \usebeamerfont{section title}
@@ -282,7 +284,6 @@
     \fi
   \end{minipage}
   \par
-  \vspace{\baselineskip}
 }
 \newcommand{\moloch@disablesectionpage}{
   \AtBeginSection{

--- a/src/beamerinnerthememoloch.dtx
+++ b/src/beamerinnerthememoloch.dtx
@@ -269,8 +269,6 @@
 \defbeamertemplate{section page}{progressbar}{
   \centering
   \begin{minipage}{0.7875\linewidth}
-    \null%
-    \vfil%
     \raggedright
     \usebeamercolor[fg]{section title}
     \usebeamerfont{section title}

--- a/src/beamerinnerthememoloch.dtx
+++ b/src/beamerinnerthememoloch.dtx
@@ -259,12 +259,15 @@
     \usebeamercolor[fg]{section title}
     \usebeamerfont{section title}
     \moloch@sectiontitleformat{\insertsectionhead}\par
-    \ifx\insertsubsectionhead\@empty\else
-      \usebeamercolor[fg]{subsection title}
-      \usebeamerfont{subsection title}
+    \usebeamercolor[fg]{subsection title}%
+    \usebeamerfont{subsection title}%
+    \ifx\insertsubsectionhead\@empty%
+      \vphantom{\insertsubsectionhead}
+    \else%
       \insertsubsectionhead
     \fi
   \end{center}
+  \vspace{\baselineskip - 1ex + 0.4pt}
 }
 \defbeamertemplate{section page}{progressbar}{
   \centering
@@ -272,13 +275,15 @@
     \raggedright
     \usebeamercolor[fg]{section title}
     \usebeamerfont{section title}
-    \moloch@sectiontitleformat{\insertsectionhead}\\[-1ex]
+    \moloch@sectiontitleformat{\insertsectionhead}\\[-0.5\baselineskip]
     \usebeamertemplate*{progress bar in section page}
     \par
-    \ifx\insertsubsectionhead\@empty\else%
-      \usebeamercolor[fg]{subsection title}%
-      \usebeamerfont{subsection title}%
-      \insertsubsectionhead
+    \usebeamercolor[fg]{subsection title}%
+    \usebeamerfont{subsection title}%
+    \ifx\insertsubsectionhead\@empty%
+      \vphantom{\insertsubsectionhead}%
+    \else%
+      \insertsubsectionhead%
     \fi
   \end{minipage}
   \par

--- a/src/beamerinnerthememoloch.dtx
+++ b/src/beamerinnerthememoloch.dtx
@@ -261,10 +261,9 @@
     \moloch@sectiontitleformat{\insertsectionhead}\par
     \usebeamercolor[fg]{subsection title}%
     \usebeamerfont{subsection title}%
-    \ifx\insertsubsectionhead\@empty%
-      \vphantom{\insertsubsectionhead}
-    \else%
-      \insertsubsectionhead
+    \strut%
+    \ifx\insertsubsectionhead\@empty\else%
+      \insertsubsectionhead%
     \fi
   \end{center}
   \vspace{\baselineskip - 1ex + 0.4pt}
@@ -280,9 +279,8 @@
     \par
     \usebeamercolor[fg]{subsection title}%
     \usebeamerfont{subsection title}%
-    \ifx\insertsubsectionhead\@empty%
-      \vphantom{\insertsubsectionhead}%
-    \else%
+    \strut%
+    \ifx\insertsubsectionhead\@empty\else%
       \insertsubsectionhead%
     \fi
   \end{minipage}

--- a/testfiles/sectionpages.lvt
+++ b/testfiles/sectionpages.lvt
@@ -1,0 +1,1 @@
+\input{sectionpages}

--- a/testfiles/sectionpages.tlg
+++ b/testfiles/sectionpages.tlg
@@ -1,0 +1,2347 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+Completed box being shipped out [2]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\pdfdest name{Navigation2} xyz
+...\penalty 10000
+...\pdfdest name{page.2} xyz
+...\penalty 10000
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.98 g 0.98 G}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x-56.90549
+........\hbox(0.0+0.0)x0.0
+.........\hbox(265.20912+0.0)x-28.45274, shifted 265.20912
+..........\hbox(265.20912+0.0)x-28.45274
+...........\glue -28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+.........\hbox(265.20912+0.0)x335.74261, shifted 265.20912
+..........\hbox(265.20912+0.0)x335.74261
+...........\glue 307.28987
+...........\glue 28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(265.20912+0.0)x0.0, glue set 256.20912fill
+............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+............\glue 0.0 plus 1.0fill
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.10294 0.16177 0.17352 rg 0.10294 0.16177 0.17352 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\glue 2.0
+............\glue(\baselineskip) 5.0
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\pdfcolorstack 0 push {0.6429 0.67427 0.68054 rg 0.6429 0.67427 0.68054 RG}
+.............\pdfcolorstack 0 pop
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 2.0
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x-56.90549
+.........\glue -28.45274
+.........\hbox(0.0+0.0)x0.0
+..........\vbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.........\glue -28.45274
+........\glue 0.0 plus 1.0fil
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(261.20912+0.0)x307.28987
+....\write-{}
+....\glue(\topskip) 0.0
+....\vbox(261.20912+0.0)x307.28987, glue set 122.73999fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\baselineskip) 5.99579
+.....\hbox(7.60422+2.12914)x307.28987, glue set 46.45671fil
+......\hbox(0.0+0.0)x0.0
+......\OT1/lmss/m/n/10.95 S
+......\OT1/lmss/m/n/10.95 e
+......\OT1/lmss/m/n/10.95 c
+......\OT1/lmss/m/n/10.95 t
+......\OT1/lmss/m/n/10.95 i
+......\OT1/lmss/m/n/10.95 o
+......\OT1/lmss/m/n/10.95 n
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 :
+......\glue 4.86665 plus 3.65 minus 0.60832
+......\OT1/lmss/m/n/10.95 p
+......\kern-0.30418
+......\OT1/lmss/m/n/10.95 r
+......\OT1/lmss/m/n/10.95 o
+......\OT1/lmss/m/n/10.95 g
+......\OT1/lmss/m/n/10.95 r
+......\OT1/lmss/m/n/10.95 e
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 b
+......\OT1/lmss/m/n/10.95 a
+......\kern-0.30418
+......\OT1/lmss/m/n/10.95 r
+......\OT1/lmss/m/n/10.95 ,
+......\glue 3.65 plus 2.28123 minus 0.97333
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 u
+......\OT1/lmss/m/n/10.95 b
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 e
+......\OT1/lmss/m/n/10.95 c
+......\OT1/lmss/m/n/10.95 t
+......\OT1/lmss/m/n/10.95 i
+......\OT1/lmss/m/n/10.95 o
+......\OT1/lmss/m/n/10.95 n
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 :
+......\glue 4.86665 plus 3.65 minus 0.60832
+......\OT1/lmss/m/n/10.95 p
+......\kern-0.30418
+......\OT1/lmss/m/n/10.95 r
+......\OT1/lmss/m/n/10.95 o
+......\OT1/lmss/m/n/10.95 g
+......\OT1/lmss/m/n/10.95 r
+......\OT1/lmss/m/n/10.95 e
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 b
+......\OT1/lmss/m/n/10.95 a
+......\kern-0.30418
+......\OT1/lmss/m/n/10.95 r
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\glue 0.0 plus 1.0fil
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {0}{0}{2}{2/2}{}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {2}{2}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 4.0
+...\hbox(7.9375+0.0)x307.28987
+....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+....\hbox(7.9375+0.0)x307.28987
+.....\vbox(7.9375+0.0)x307.28987
+......\hbox(7.9375+0.0)x307.28987
+.......\hbox(7.9375+0.0)x307.28987
+........\glue -28.45274
+........\hbox(7.9375+0.0)x364.19536
+.........\vbox(7.9375+0.0)x364.19536
+..........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+..........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+..........\hbox(7.9375+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\vbox(7.9375+0.0)x364.19536
+............\hbox(3.9375+0.0)x364.19536, glue set 352.00786fill
+.............\glue(\leftskip) 4.0
+.............\hbox(0.0+0.0)x0.0
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 0.0 plus 1.0fill
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\hbox(3.9375+0.0)x3.1875
+..............\glue 0.0 plus 1.0fil minus 1.0fil
+..............\OT1/lmss/m/n/6 1
+.............\pdfcolorstack 0 pop
+.............\penalty 10000
+.............\glue(\parfillskip) 0.0 plus 1.0fil
+.............\glue(\rightskip) 5.0
+............\glue 4.0
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+........\glue -28.45274
+.......\glue 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fil
+......\glue(\lineskip) 0.0
+......\hbox(0.0+0.0)x0.0
+.....\glue 0.0 plus 1.0fil
+....\pdfcolorstack 0 pop
+.\kern 0.0
+LaTeX Font Info:    Trying to load font information for OML+lmm on input line ....
+LaTeX Font Info:    Trying to load font information for OMS+lmsy on input line ....
+LaTeX Font Info:    Trying to load font information for OMX+lmex on input line ....
+LaTeX Font Info:    External font `lmex10' loaded for size
+(Font)              <10.95> on input line ....
+LaTeX Font Info:    External font `lmex10' loaded for size
+(Font)              <8> on input line ....
+LaTeX Font Info:    External font `lmex10' loaded for size
+(Font)              <6> on input line ....
+LaTeX Font Info:    Trying to load font information for U+msa on input line ....
+LaTeX Font Info:    Trying to load font information for U+msb on input line ....
+LaTeX Font Info:    Font shape `OT1/lmss/m/it' in size <10.95> not available
+(Font)              Font shape `OT1/lmss/m/sl' tried instead on input line ....
+LaTeX Font Info:    Font shape `OT1/lmss/m/it' in size <8> not available
+(Font)              Font shape `OT1/lmss/m/sl' tried instead on input line ....
+LaTeX Font Info:    Font shape `OT1/lmss/m/it' in size <6> not available
+(Font)              Font shape `OT1/lmss/m/sl' tried instead on input line ....
+Completed box being shipped out [3]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\pdfdest name{Navigation3} xyz
+...\penalty 10000
+...\pdfdest name{page.3} xyz
+...\penalty 10000
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.98 g 0.98 G}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(261.20912+0.0)x307.28987
+....\write-{}
+....\write1{\@writefile{toc}{\protect \beamer@sectionintoc {1}{Section}{3}{0}{1}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@sectionpages {1}{2}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@subsectionpages {1}{2}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \sectionentry {1}{Section}{3}{Section}{0}}}}
+....\write5{\protect \BOOKMARK [2][]{Outline0.1}{\376\377\000S\000e\000c\000t\000i\000o\000n}{}% 1}
+....\pdfdest name{Outline0.1} xyz
+....\glue(\topskip) 0.0
+....\vbox(261.20912+0.0)x307.28987, glue set 120.07327fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\rule(0.0+0.0)x*
+.....\penalty 10000
+.....\glue 0.0
+.....\glue 0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(19.23753+13.76254)x307.28987, glue set 32.64862fil
+......\glue(\leftskip) 0.0 plus 1.0fil
+......\hbox(0.0+0.0)x0.0
+......\mathon
+......\vbox(19.23753+13.76254)x241.99265
+.......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\hbox(10.00008+0.0)x241.99265, glue set 96.64658fil
+........\hbox(0.0+0.0)x0.0
+........\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/N/C[.5 .5 .5]} action goto name{Navigation3}
+........\OT1/lmss/bx/n/14.4 S
+........\OT1/lmss/bx/n/14.4 e
+........\OT1/lmss/bx/n/14.4 c
+........\OT1/lmss/bx/n/14.4 t
+........\OT1/lmss/bx/n/14.4 i
+........\OT1/lmss/bx/n/14.4 o
+........\OT1/lmss/bx/n/14.4 n
+........\pdfendlink
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0 plus 1.0fil
+.......\glue 0.0
+.......\glue -9.0
+.......\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 17.6
+.......\hbox(0.4+0.0)x241.99265
+........\hbox(0.0+0.0)x0.0
+........\hbox(0.4+0.0)x241.99265
+.........\glue 0.0
+.........\hbox(0.0+0.0)x0.0
+..........\pdfliteral{q }
+..........\pdfliteral{0.92157 0.50587 0.10588 RG }
+..........\pdfliteral{0.92157 0.50587 0.10588 rg }
+..........\pdfliteral{0.3985 w }
+..........\hbox(0.0+0.0)x0.0
+...........\pdfliteral{q }
+...........\glue 0.0
+...........\pdfliteral{q }
+...........\pdfcolorstack 0 push {0.83824 0.77588 0.71588 rg 0.83824 0.77588 0.71588 RG}
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.3985 l }
+...........\pdfliteral{241.09166 0.3985 l }
+...........\pdfliteral{241.09166 0.0 l }
+...........\pdfliteral{h }
+...........\pdfliteral{241.09166 0.3985 m }
+...........\pdfliteral{f }
+...........\glue 0.0
+...........\pdfcolorstack 0 pop
+...........\pdfliteral{Q }
+...........\glue 0.0
+...........\pdfliteral{q }
+...........\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.3985 l }
+...........\pdfliteral{80.36266 0.3985 l }
+...........\pdfliteral{80.36266 0.0 l }
+...........\pdfliteral{h }
+...........\pdfliteral{80.36266 0.3985 m }
+...........\pdfliteral{f }
+...........\glue 0.0
+...........\pdfcolorstack 0 pop
+...........\pdfliteral{Q }
+...........\glue 0.0
+...........\pdfliteral{Q }
+...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\pdfliteral{n }
+..........\pdfliteral{Q }
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+........\pdfcolorstack 0 pop
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0 plus 1.0fil
+.......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 14.0
+.......\hbox(0.0+0.0)x241.99265, glue set 120.99632fil
+........\hbox(0.0+0.0)x0.0
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0 plus 1.0fil
+.......\pdfcolorstack 0 pop
+.......\pdfcolorstack 0 pop
+......\mathoff
+......\penalty 10000
+......\glue(\parfillskip) 0.0
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\pdfcolorstack 0 pop
+.....\glue 0.0 plus 1.0fil
+.....\rule(0.0+0.0)x*
+.....\penalty 10000
+.....\glue -11.9375
+.....\glue 0.0
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {1}{0}{1}{3/3}{}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {3}{3}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 11.9375
+...\hbox(0.0+0.0)x307.28987
+....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+....\hbox(0.0+0.0)x307.28987, glue set 333.74261fil
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue 0.0 plus 1.0fil
+.....\hbox(0.0+0.0)x-26.45274
+......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+......\pdfcolorstack 0 push {0.6429 0.67427 0.68054 rg 0.6429 0.67427 0.68054 RG}
+......\pdfcolorstack 0 pop
+......\pdfcolorstack 0 pop
+......\glue -28.45274
+......\glue 2.0
+....\pdfcolorstack 0 pop
+....\pdfcolorstack 0 pop
+.\kern 0.0
+Completed box being shipped out [4]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\pdfdest name{Navigation4} xyz
+...\penalty 10000
+...\pdfdest name{page.4} xyz
+...\penalty 10000
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.98 g 0.98 G}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(261.20912+0.0)x307.28987
+....\write-{}
+....\write1{\@writefile{toc}{\protect \beamer@subsectionintoc {1}{1}{Subsection}{4}{0}{1}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@subsectionpages {3}{3}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@subsectionentry {0}{1}{1}{4}{Subsection}}}}
+....\write5{\protect \BOOKMARK [3][]{Outline0.1.1.4}{\376\377\000S\000u\000b\000s\000e\000c\000t\000i\000o\000n}{Outline0.1}% 2}
+....\pdfdest name{Outline0.1.1.4} xyz
+....\glue(\topskip) 0.0
+....\vbox(261.20912+0.0)x307.28987, glue set 120.07327fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\rule(0.0+0.0)x*
+.....\penalty 10000
+.....\glue 0.0
+.....\glue 0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(19.23753+13.76254)x307.28987, glue set 32.64862fil
+......\glue(\leftskip) 0.0 plus 1.0fil
+......\hbox(0.0+0.0)x0.0
+......\mathon
+......\vbox(19.23753+13.76254)x241.99265
+.......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\hbox(10.00008+0.0)x241.99265, glue set 96.64658fil
+........\hbox(0.0+0.0)x0.0
+........\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/N/C[.5 .5 .5]} action goto name{Navigation3}
+........\OT1/lmss/bx/n/14.4 S
+........\OT1/lmss/bx/n/14.4 e
+........\OT1/lmss/bx/n/14.4 c
+........\OT1/lmss/bx/n/14.4 t
+........\OT1/lmss/bx/n/14.4 i
+........\OT1/lmss/bx/n/14.4 o
+........\OT1/lmss/bx/n/14.4 n
+........\pdfendlink
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0 plus 1.0fil
+.......\glue 0.0
+.......\glue -9.0
+.......\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 17.6
+.......\hbox(0.4+0.0)x241.99265
+........\hbox(0.0+0.0)x0.0
+........\hbox(0.4+0.0)x241.99265
+.........\glue 0.0
+.........\hbox(0.0+0.0)x0.0
+..........\pdfliteral{q }
+..........\pdfliteral{0.92157 0.50587 0.10588 RG }
+..........\pdfliteral{0.92157 0.50587 0.10588 rg }
+..........\pdfliteral{0.3985 w }
+..........\hbox(0.0+0.0)x0.0
+...........\pdfliteral{q }
+...........\glue 0.0
+...........\pdfliteral{q }
+...........\pdfcolorstack 0 push {0.83824 0.77588 0.71588 rg 0.83824 0.77588 0.71588 RG}
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.3985 l }
+...........\pdfliteral{241.09166 0.3985 l }
+...........\pdfliteral{241.09166 0.0 l }
+...........\pdfliteral{h }
+...........\pdfliteral{241.09166 0.3985 m }
+...........\pdfliteral{f }
+...........\glue 0.0
+...........\pdfcolorstack 0 pop
+...........\pdfliteral{Q }
+...........\glue 0.0
+...........\pdfliteral{q }
+...........\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.3985 l }
+...........\pdfliteral{80.36266 0.3985 l }
+...........\pdfliteral{80.36266 0.0 l }
+...........\pdfliteral{h }
+...........\pdfliteral{80.36266 0.3985 m }
+...........\pdfliteral{f }
+...........\glue 0.0
+...........\pdfcolorstack 0 pop
+...........\pdfliteral{Q }
+...........\glue 0.0
+...........\pdfliteral{Q }
+...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\pdfliteral{n }
+..........\pdfliteral{Q }
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+........\pdfcolorstack 0 pop
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0 plus 1.0fil
+.......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 5.6666
+.......\hbox(8.3334+0.0)x241.99265, glue set 91.44168fil
+........\hbox(0.0+0.0)x0.0
+........\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/N/C[.5 .5 .5]} action goto name{Navigation4}
+........\OT1/lmss/bx/n/12 S
+........\OT1/lmss/bx/n/12 u
+........\OT1/lmss/bx/n/12 b
+........\OT1/lmss/bx/n/12 s
+........\OT1/lmss/bx/n/12 e
+........\OT1/lmss/bx/n/12 c
+........\OT1/lmss/bx/n/12 t
+........\OT1/lmss/bx/n/12 i
+........\OT1/lmss/bx/n/12 o
+........\OT1/lmss/bx/n/12 n
+........\pdfendlink
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0 plus 1.0fil
+.......\pdfcolorstack 0 pop
+.......\pdfcolorstack 0 pop
+......\mathoff
+......\penalty 10000
+......\glue(\parfillskip) 0.0
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 pop
+.....\glue 0.0 plus 1.0fil
+.....\rule(0.0+0.0)x*
+.....\penalty 10000
+.....\glue -11.9375
+.....\glue 0.0
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {1}{1}{1}{4/4}{Subsection}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {4}{4}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 11.9375
+...\hbox(0.0+0.0)x307.28987
+....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+....\hbox(0.0+0.0)x307.28987, glue set 333.74261fil
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue 0.0 plus 1.0fil
+.....\hbox(0.0+0.0)x-26.45274
+......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+......\pdfcolorstack 0 push {0.6429 0.67427 0.68054 rg 0.6429 0.67427 0.68054 RG}
+......\pdfcolorstack 0 pop
+......\pdfcolorstack 0 pop
+......\glue -28.45274
+......\glue 2.0
+....\pdfcolorstack 0 pop
+....\pdfcolorstack 0 pop
+.\kern 0.0
+Completed box being shipped out [5]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\pdfdest name{Navigation5} xyz
+...\penalty 10000
+...\pdfdest name{page.5} xyz
+...\penalty 10000
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.98 g 0.98 G}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x-56.90549
+........\hbox(0.0+0.0)x0.0
+.........\hbox(265.20912+0.0)x-28.45274, shifted 265.20912
+..........\hbox(265.20912+0.0)x-28.45274
+...........\glue -28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+.........\hbox(265.20912+0.0)x335.74261, shifted 265.20912
+..........\hbox(265.20912+0.0)x335.74261
+...........\glue 307.28987
+...........\glue 28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(265.20912+0.0)x0.0, glue set 256.20912fill
+............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+............\glue 0.0 plus 1.0fill
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.10294 0.16177 0.17352 rg 0.10294 0.16177 0.17352 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\glue 2.0
+............\glue(\baselineskip) 5.0
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\pdfcolorstack 0 push {0.6429 0.67427 0.68054 rg 0.6429 0.67427 0.68054 RG}
+.............\pdfcolorstack 0 pop
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 2.0
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x-56.90549
+.........\glue -28.45274
+.........\hbox(0.0+0.0)x0.0
+..........\vbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.........\glue -28.45274
+........\glue 0.0 plus 1.0fil
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(261.20912+0.0)x307.28987
+....\write-{}
+....\glue(\topskip) 0.0
+....\vbox(261.20912+0.0)x307.28987, glue set 122.73999fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\baselineskip) 5.99579
+.....\hbox(7.60422+2.12914)x307.28987, glue set 57.83232fil
+......\hbox(0.0+0.0)x0.0
+......\OT1/lmss/m/n/10.95 S
+......\OT1/lmss/m/n/10.95 e
+......\OT1/lmss/m/n/10.95 c
+......\OT1/lmss/m/n/10.95 t
+......\OT1/lmss/m/n/10.95 i
+......\OT1/lmss/m/n/10.95 o
+......\OT1/lmss/m/n/10.95 n
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 :
+......\glue 4.86665 plus 3.65 minus 0.60832
+......\OT1/lmss/m/n/10.95 p
+......\kern-0.30418
+......\OT1/lmss/m/n/10.95 r
+......\OT1/lmss/m/n/10.95 o
+......\OT1/lmss/m/n/10.95 g
+......\OT1/lmss/m/n/10.95 r
+......\OT1/lmss/m/n/10.95 e
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 b
+......\OT1/lmss/m/n/10.95 a
+......\kern-0.30418
+......\OT1/lmss/m/n/10.95 r
+......\OT1/lmss/m/n/10.95 ,
+......\glue 3.65 plus 2.28123 minus 0.97333
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 u
+......\OT1/lmss/m/n/10.95 b
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 e
+......\OT1/lmss/m/n/10.95 c
+......\OT1/lmss/m/n/10.95 t
+......\OT1/lmss/m/n/10.95 i
+......\OT1/lmss/m/n/10.95 o
+......\OT1/lmss/m/n/10.95 n
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 :
+......\glue 4.86665 plus 3.65 minus 0.60832
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 i
+......\OT1/lmss/m/n/10.95 m
+......\OT1/lmss/m/n/10.95 p
+......\OT1/lmss/m/n/10.95 l
+......\OT1/lmss/m/n/10.95 e
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\glue 0.0 plus 1.0fil
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {1}{1}{2}{5/5}{Subsection}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {5}{5}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 4.0
+...\hbox(7.9375+0.0)x307.28987
+....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+....\hbox(7.9375+0.0)x307.28987
+.....\vbox(7.9375+0.0)x307.28987
+......\hbox(7.9375+0.0)x307.28987
+.......\hbox(7.9375+0.0)x307.28987
+........\glue -28.45274
+........\hbox(7.9375+0.0)x364.19536
+.........\vbox(7.9375+0.0)x364.19536
+..........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+..........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+..........\hbox(7.9375+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\vbox(7.9375+0.0)x364.19536
+............\hbox(3.9375+0.0)x364.19536, glue set 352.00786fill
+.............\glue(\leftskip) 4.0
+.............\hbox(0.0+0.0)x0.0
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 0.0 plus 1.0fill
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\hbox(3.9375+0.0)x3.1875
+..............\glue 0.0 plus 1.0fil minus 1.0fil
+..............\OT1/lmss/m/n/6 2
+.............\pdfcolorstack 0 pop
+.............\penalty 10000
+.............\glue(\parfillskip) 0.0 plus 1.0fil
+.............\glue(\rightskip) 5.0
+............\glue 4.0
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+........\glue -28.45274
+.......\glue 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fil
+......\glue(\lineskip) 0.0
+......\hbox(0.0+0.0)x0.0
+.....\glue 0.0 plus 1.0fil
+....\pdfcolorstack 0 pop
+.\kern 0.0
+Completed box being shipped out [6]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\pdfdest name{Navigation6} xyz
+...\penalty 10000
+...\pdfdest name{page.6} xyz
+...\penalty 10000
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.98 g 0.98 G}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(261.20912+0.0)x307.28987
+....\write-{}
+....\write1{\@writefile{toc}{\protect \beamer@sectionintoc {2}{Section}{6}{0}{2}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@sectionpages {3}{5}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@subsectionpages {4}{5}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \sectionentry {2}{Section}{6}{Section}{0}}}}
+....\write5{\protect \BOOKMARK [2][]{Outline0.2}{\376\377\000S\000e\000c\000t\000i\000o\000n}{}% 3}
+....\pdfdest name{Outline0.2} xyz
+....\glue(\topskip) 0.0
+....\vbox(261.20912+0.0)x307.28987, glue set 120.07327fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\rule(0.0+0.0)x*
+.....\penalty 10000
+.....\glue 0.0
+.....\glue 0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(19.23753+13.76254)x307.28987, glue set 32.64862fil
+......\glue(\leftskip) 0.0 plus 1.0fil
+......\hbox(0.0+0.0)x0.0
+......\mathon
+......\vbox(19.23753+13.76254)x241.99265
+.......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\hbox(10.00008+0.0)x241.99265, glue set 96.64658fil
+........\hbox(0.0+0.0)x0.0
+........\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/N/C[.5 .5 .5]} action goto name{Navigation6}
+........\OT1/lmss/bx/n/14.4 S
+........\OT1/lmss/bx/n/14.4 e
+........\OT1/lmss/bx/n/14.4 c
+........\OT1/lmss/bx/n/14.4 t
+........\OT1/lmss/bx/n/14.4 i
+........\OT1/lmss/bx/n/14.4 o
+........\OT1/lmss/bx/n/14.4 n
+........\pdfendlink
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0 plus 1.0fil
+.......\glue 0.0
+.......\glue -9.0
+.......\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 17.6
+.......\hbox(0.4+0.0)x241.99265
+........\hbox(0.0+0.0)x0.0
+........\hbox(0.4+0.0)x241.99265
+.........\glue 0.0
+.........\hbox(0.0+0.0)x0.0
+..........\pdfliteral{q }
+..........\pdfliteral{0.92157 0.50587 0.10588 RG }
+..........\pdfliteral{0.92157 0.50587 0.10588 rg }
+..........\pdfliteral{0.3985 w }
+..........\hbox(0.0+0.0)x0.0
+...........\pdfliteral{q }
+...........\glue 0.0
+...........\pdfliteral{q }
+...........\pdfcolorstack 0 push {0.83824 0.77588 0.71588 rg 0.83824 0.77588 0.71588 RG}
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.3985 l }
+...........\pdfliteral{241.09166 0.3985 l }
+...........\pdfliteral{241.09166 0.0 l }
+...........\pdfliteral{h }
+...........\pdfliteral{241.09166 0.3985 m }
+...........\pdfliteral{f }
+...........\glue 0.0
+...........\pdfcolorstack 0 pop
+...........\pdfliteral{Q }
+...........\glue 0.0
+...........\pdfliteral{q }
+...........\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.3985 l }
+...........\pdfliteral{160.72531 0.3985 l }
+...........\pdfliteral{160.72531 0.0 l }
+...........\pdfliteral{h }
+...........\pdfliteral{160.72531 0.3985 m }
+...........\pdfliteral{f }
+...........\glue 0.0
+...........\pdfcolorstack 0 pop
+...........\pdfliteral{Q }
+...........\glue 0.0
+...........\pdfliteral{Q }
+...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\pdfliteral{n }
+..........\pdfliteral{Q }
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+........\pdfcolorstack 0 pop
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0 plus 1.0fil
+.......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 14.0
+.......\hbox(0.0+0.0)x241.99265, glue set 120.99632fil
+........\hbox(0.0+0.0)x0.0
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0 plus 1.0fil
+.......\pdfcolorstack 0 pop
+.......\pdfcolorstack 0 pop
+......\mathoff
+......\penalty 10000
+......\glue(\parfillskip) 0.0
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\pdfcolorstack 0 pop
+.....\glue 0.0 plus 1.0fil
+.....\rule(0.0+0.0)x*
+.....\penalty 10000
+.....\glue -11.9375
+.....\glue 0.0
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {2}{0}{1}{6/6}{}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {6}{6}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 11.9375
+...\hbox(0.0+0.0)x307.28987
+....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+....\hbox(0.0+0.0)x307.28987, glue set 333.74261fil
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue 0.0 plus 1.0fil
+.....\hbox(0.0+0.0)x-26.45274
+......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+......\pdfcolorstack 0 push {0.6429 0.67427 0.68054 rg 0.6429 0.67427 0.68054 RG}
+......\pdfcolorstack 0 pop
+......\pdfcolorstack 0 pop
+......\glue -28.45274
+......\glue 2.0
+....\pdfcolorstack 0 pop
+....\pdfcolorstack 0 pop
+.\kern 0.0
+Completed box being shipped out [7]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\pdfdest name{Navigation7} xyz
+...\penalty 10000
+...\pdfdest name{page.7} xyz
+...\penalty 10000
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.98 g 0.98 G}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(261.20912+0.0)x307.28987
+....\write-{}
+....\write1{\@writefile{toc}{\protect \beamer@subsectionintoc {2}{1}{Subsection}{7}{0}{2}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@subsectionpages {6}{6}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@subsectionentry {0}{2}{1}{7}{Subsection}}}}
+....\write5{\protect \BOOKMARK [3][]{Outline0.2.1.7}{\376\377\000S\000u\000b\000s\000e\000c\000t\000i\000o\000n}{Outline0.2}% 4}
+....\pdfdest name{Outline0.2.1.7} xyz
+....\glue(\topskip) 0.0
+....\vbox(261.20912+0.0)x307.28987, glue set 111.00664fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\rule(0.0+0.0)x*
+.....\penalty 10000
+.....\glue 0.0
+.....\glue 0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\penalty -51
+.....\glue 9.0 plus 3.0 minus 5.0
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.00008+0.0)x307.28987, glue set 129.29518fil
+......\glue(\leftskip) 0.0 plus 1.0fil
+......\hbox(0.0+0.0)x0.0
+.......\glue 0.0
+.......\glue 0.0
+.......\glue -5.475
+.......\hbox(0.0+0.0)x0.0
+........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+........\pdfcolorstack 0 pop
+.......\glue 5.475
+......\penalty 0
+......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/N/C[.5 .5 .5]} action goto name{Navigation6}
+......\OT1/lmss/bx/n/14.4 S
+......\OT1/lmss/bx/n/14.4 e
+......\OT1/lmss/bx/n/14.4 c
+......\OT1/lmss/bx/n/14.4 t
+......\OT1/lmss/bx/n/14.4 i
+......\OT1/lmss/bx/n/14.4 o
+......\OT1/lmss/bx/n/14.4 n
+......\pdfendlink
+......\penalty 10000
+......\glue(\parfillskip) 0.0
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\baselineskip) 5.6666
+.....\hbox(8.3334+0.0)x307.28987, glue set 124.09029fil
+......\glue(\leftskip) 0.0 plus 1.0fil
+......\hbox(0.0+0.0)x0.0
+......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/N/C[.5 .5 .5]} action goto name{Navigation7}
+......\OT1/lmss/bx/n/12 S
+......\OT1/lmss/bx/n/12 u
+......\OT1/lmss/bx/n/12 b
+......\OT1/lmss/bx/n/12 s
+......\OT1/lmss/bx/n/12 e
+......\OT1/lmss/bx/n/12 c
+......\OT1/lmss/bx/n/12 t
+......\OT1/lmss/bx/n/12 i
+......\OT1/lmss/bx/n/12 o
+......\OT1/lmss/bx/n/12 n
+......\pdfendlink
+......\penalty 10000
+......\glue(\parfillskip) 0.0
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\penalty -51
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 pop
+.....\glue 9.0 plus 3.0 minus 5.0
+.....\glue 9.13327
+.....\glue 0.0
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 pop
+.....\glue 0.0 plus 1.0fil
+.....\rule(0.0+0.0)x*
+.....\penalty 10000
+.....\glue -11.9375
+.....\glue 0.0
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {2}{1}{1}{7/7}{Subsection}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {7}{7}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 11.9375
+...\hbox(0.0+0.0)x307.28987
+....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+....\hbox(0.0+0.0)x307.28987, glue set 333.74261fil
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue 0.0 plus 1.0fil
+.....\hbox(0.0+0.0)x-26.45274
+......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+......\pdfcolorstack 0 push {0.6429 0.67427 0.68054 rg 0.6429 0.67427 0.68054 RG}
+......\pdfcolorstack 0 pop
+......\pdfcolorstack 0 pop
+......\glue -28.45274
+......\glue 2.0
+....\pdfcolorstack 0 pop
+....\pdfcolorstack 0 pop
+.\kern 0.0
+Completed box being shipped out [8]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\pdfdest name{Navigation8} xyz
+...\penalty 10000
+...\pdfdest name{page.8} xyz
+...\penalty 10000
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.98 g 0.98 G}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(261.20912+0.0)x307.28987
+....\write-{}
+....\write1{\@writefile{toc}{\protect \beamer@sectionintoc {3}{Section}{8}{0}{3}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@sectionpages {6}{7}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@subsectionpages {7}{7}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \sectionentry {3}{Section}{8}{Section}{0}}}}
+....\write5{\protect \BOOKMARK [2][]{Outline0.3}{\376\377\000S\000e\000c\000t\000i\000o\000n}{}% 5}
+....\pdfdest name{Outline0.3} xyz
+....\glue(\topskip) 0.0
+....\vbox(261.20912+0.0)x307.28987, glue set 120.07327fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\rule(0.0+0.0)x*
+.....\penalty 10000
+.....\glue 0.0
+.....\glue 0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(19.23753+13.76254)x307.28987, glue set 32.64862fil
+......\glue(\leftskip) 0.0 plus 1.0fil
+......\hbox(0.0+0.0)x0.0
+......\mathon
+......\vbox(19.23753+13.76254)x241.99265
+.......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\hbox(10.00008+0.0)x241.99265, glue set 96.64658fil
+........\hbox(0.0+0.0)x0.0
+........\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/N/C[.5 .5 .5]} action goto name{Navigation8}
+........\OT1/lmss/bx/n/14.4 S
+........\OT1/lmss/bx/n/14.4 e
+........\OT1/lmss/bx/n/14.4 c
+........\OT1/lmss/bx/n/14.4 t
+........\OT1/lmss/bx/n/14.4 i
+........\OT1/lmss/bx/n/14.4 o
+........\OT1/lmss/bx/n/14.4 n
+........\pdfendlink
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0 plus 1.0fil
+.......\glue 0.0
+.......\glue -9.0
+.......\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 17.6
+.......\hbox(0.4+0.0)x241.99265
+........\hbox(0.0+0.0)x0.0
+........\hbox(0.4+0.0)x241.99265
+.........\glue 0.0
+.........\hbox(0.0+0.0)x0.0
+..........\pdfliteral{q }
+..........\pdfliteral{0.92157 0.50587 0.10588 RG }
+..........\pdfliteral{0.92157 0.50587 0.10588 rg }
+..........\pdfliteral{0.3985 w }
+..........\hbox(0.0+0.0)x0.0
+...........\pdfliteral{q }
+...........\glue 0.0
+...........\pdfliteral{q }
+...........\pdfcolorstack 0 push {0.83824 0.77588 0.71588 rg 0.83824 0.77588 0.71588 RG}
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.3985 l }
+...........\pdfliteral{241.09166 0.3985 l }
+...........\pdfliteral{241.09166 0.0 l }
+...........\pdfliteral{h }
+...........\pdfliteral{241.09166 0.3985 m }
+...........\pdfliteral{f }
+...........\glue 0.0
+...........\pdfcolorstack 0 pop
+...........\pdfliteral{Q }
+...........\glue 0.0
+...........\pdfliteral{q }
+...........\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.3985 l }
+...........\pdfliteral{160.72531 0.3985 l }
+...........\pdfliteral{160.72531 0.0 l }
+...........\pdfliteral{h }
+...........\pdfliteral{160.72531 0.3985 m }
+...........\pdfliteral{f }
+...........\glue 0.0
+...........\pdfcolorstack 0 pop
+...........\pdfliteral{Q }
+...........\glue 0.0
+...........\pdfliteral{Q }
+...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\pdfliteral{n }
+..........\pdfliteral{Q }
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+........\pdfcolorstack 0 pop
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0 plus 1.0fil
+.......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 14.0
+.......\hbox(0.0+0.0)x241.99265, glue set 120.99632fil
+........\hbox(0.0+0.0)x0.0
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0 plus 1.0fil
+.......\pdfcolorstack 0 pop
+.......\pdfcolorstack 0 pop
+......\mathoff
+......\penalty 10000
+......\glue(\parfillskip) 0.0
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\pdfcolorstack 0 pop
+.....\glue 0.0 plus 1.0fil
+.....\rule(0.0+0.0)x*
+.....\penalty 10000
+.....\glue -11.9375
+.....\glue 0.0
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {3}{0}{1}{8/8}{}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {8}{8}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 11.9375
+...\hbox(0.0+0.0)x307.28987
+....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+....\hbox(0.0+0.0)x307.28987, glue set 333.74261fil
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue 0.0 plus 1.0fil
+.....\hbox(0.0+0.0)x-26.45274
+......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+......\pdfcolorstack 0 push {0.6429 0.67427 0.68054 rg 0.6429 0.67427 0.68054 RG}
+......\pdfcolorstack 0 pop
+......\pdfcolorstack 0 pop
+......\glue -28.45274
+......\glue 2.0
+....\pdfcolorstack 0 pop
+....\pdfcolorstack 0 pop
+.\kern 0.0
+Completed box being shipped out [9]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\pdfdest name{Navigation9} xyz
+...\penalty 10000
+...\pdfdest name{page.9} xyz
+...\penalty 10000
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.98 g 0.98 G}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(261.20912+0.0)x307.28987
+....\write-{}
+....\write1{\@writefile{toc}{\protect \beamer@subsectionintoc {3}{1}{Subsection}{9}{0}{3}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@subsectionpages {8}{8}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@subsectionentry {0}{3}{1}{9}{Subsection}}}}
+....\write5{\protect \BOOKMARK [3][]{Outline0.3.1.9}{\376\377\000S\000u\000b\000s\000e\000c\000t\000i\000o\000n}{Outline0.3}% 6}
+....\pdfdest name{Outline0.3.1.9} xyz
+....\glue(\topskip) 0.0
+....\vbox(261.20912+0.0)x307.28987, glue set 120.07327fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\rule(0.0+0.0)x*
+.....\penalty 10000
+.....\glue 0.0
+.....\glue 0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(19.23753+13.76254)x307.28987, glue set 32.64862fil
+......\glue(\leftskip) 0.0 plus 1.0fil
+......\hbox(0.0+0.0)x0.0
+......\mathon
+......\vbox(19.23753+13.76254)x241.99265
+.......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\hbox(10.00008+0.0)x241.99265, glue set 96.64658fil
+........\hbox(0.0+0.0)x0.0
+........\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/N/C[.5 .5 .5]} action goto name{Navigation8}
+........\OT1/lmss/bx/n/14.4 S
+........\OT1/lmss/bx/n/14.4 e
+........\OT1/lmss/bx/n/14.4 c
+........\OT1/lmss/bx/n/14.4 t
+........\OT1/lmss/bx/n/14.4 i
+........\OT1/lmss/bx/n/14.4 o
+........\OT1/lmss/bx/n/14.4 n
+........\pdfendlink
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0 plus 1.0fil
+.......\glue 0.0
+.......\glue -9.0
+.......\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 17.6
+.......\hbox(0.4+0.0)x241.99265
+........\hbox(0.0+0.0)x0.0
+........\hbox(0.4+0.0)x241.99265
+.........\glue 0.0
+.........\hbox(0.0+0.0)x0.0
+..........\pdfliteral{q }
+..........\pdfliteral{0.92157 0.50587 0.10588 RG }
+..........\pdfliteral{0.92157 0.50587 0.10588 rg }
+..........\pdfliteral{0.3985 w }
+..........\hbox(0.0+0.0)x0.0
+...........\pdfliteral{q }
+...........\glue 0.0
+...........\pdfliteral{q }
+...........\pdfcolorstack 0 push {0.83824 0.77588 0.71588 rg 0.83824 0.77588 0.71588 RG}
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.3985 l }
+...........\pdfliteral{241.09166 0.3985 l }
+...........\pdfliteral{241.09166 0.0 l }
+...........\pdfliteral{h }
+...........\pdfliteral{241.09166 0.3985 m }
+...........\pdfliteral{f }
+...........\glue 0.0
+...........\pdfcolorstack 0 pop
+...........\pdfliteral{Q }
+...........\glue 0.0
+...........\pdfliteral{q }
+...........\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.0 m }
+...........\pdfliteral{0.0 0.3985 l }
+...........\pdfliteral{160.72531 0.3985 l }
+...........\pdfliteral{160.72531 0.0 l }
+...........\pdfliteral{h }
+...........\pdfliteral{160.72531 0.3985 m }
+...........\pdfliteral{f }
+...........\glue 0.0
+...........\pdfcolorstack 0 pop
+...........\pdfliteral{Q }
+...........\glue 0.0
+...........\pdfliteral{Q }
+...........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\pdfliteral{n }
+..........\pdfliteral{Q }
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+........\pdfcolorstack 0 pop
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0 plus 1.0fil
+.......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 5.6666
+.......\hbox(8.3334+0.0)x241.99265, glue set 91.44168fil
+........\hbox(0.0+0.0)x0.0
+........\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/N/C[.5 .5 .5]} action goto name{Navigation9}
+........\OT1/lmss/bx/n/12 S
+........\OT1/lmss/bx/n/12 u
+........\OT1/lmss/bx/n/12 b
+........\OT1/lmss/bx/n/12 s
+........\OT1/lmss/bx/n/12 e
+........\OT1/lmss/bx/n/12 c
+........\OT1/lmss/bx/n/12 t
+........\OT1/lmss/bx/n/12 i
+........\OT1/lmss/bx/n/12 o
+........\OT1/lmss/bx/n/12 n
+........\pdfendlink
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0 plus 1.0fil
+.......\pdfcolorstack 0 pop
+.......\pdfcolorstack 0 pop
+......\mathoff
+......\penalty 10000
+......\glue(\parfillskip) 0.0
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 pop
+.....\glue 0.0 plus 1.0fil
+.....\rule(0.0+0.0)x*
+.....\penalty 10000
+.....\glue -11.9375
+.....\glue 0.0
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {3}{1}{1}{9/9}{Subsection}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {9}{9}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 11.9375
+...\hbox(0.0+0.0)x307.28987
+....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+....\hbox(0.0+0.0)x307.28987, glue set 333.74261fil
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue 0.0 plus 1.0fil
+.....\hbox(0.0+0.0)x-26.45274
+......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+......\pdfcolorstack 0 push {0.6429 0.67427 0.68054 rg 0.6429 0.67427 0.68054 RG}
+......\pdfcolorstack 0 pop
+......\pdfcolorstack 0 pop
+......\glue -28.45274
+......\glue 2.0
+....\pdfcolorstack 0 pop
+....\pdfcolorstack 0 pop
+.\kern 0.0
+Completed box being shipped out [10]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\pdfdest name{Navigation10} xyz
+...\penalty 10000
+...\pdfdest name{page.10} xyz
+...\penalty 10000
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.98 g 0.98 G}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x-56.90549
+........\hbox(0.0+0.0)x0.0
+.........\hbox(265.20912+0.0)x-28.45274, shifted 265.20912
+..........\hbox(265.20912+0.0)x-28.45274
+...........\glue -28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+.........\hbox(265.20912+0.0)x335.74261, shifted 265.20912
+..........\hbox(265.20912+0.0)x335.74261
+...........\glue 307.28987
+...........\glue 28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(265.20912+0.0)x0.0, glue set 256.20912fill
+............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+............\glue 0.0 plus 1.0fill
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.10294 0.16177 0.17352 rg 0.10294 0.16177 0.17352 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\glue 2.0
+............\glue(\baselineskip) 5.0
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\pdfcolorstack 0 push {0.6429 0.67427 0.68054 rg 0.6429 0.67427 0.68054 RG}
+.............\pdfcolorstack 0 pop
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 2.0
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x-56.90549
+.........\glue -28.45274
+.........\hbox(0.0+0.0)x0.0
+..........\vbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.........\glue -28.45274
+........\glue 0.0 plus 1.0fil
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(261.20912+0.0)x307.28987
+....\write-{}
+....\glue(\topskip) 0.0
+....\vbox(261.20912+0.0)x307.28987, glue set 122.73999fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\baselineskip) 5.99579
+.....\hbox(7.60422+2.12914)x307.28987, glue set 69.20793fil
+......\hbox(0.0+0.0)x0.0
+......\OT1/lmss/m/n/10.95 S
+......\OT1/lmss/m/n/10.95 e
+......\OT1/lmss/m/n/10.95 c
+......\OT1/lmss/m/n/10.95 t
+......\OT1/lmss/m/n/10.95 i
+......\OT1/lmss/m/n/10.95 o
+......\OT1/lmss/m/n/10.95 n
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 :
+......\glue 4.86665 plus 3.65 minus 0.60832
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 i
+......\OT1/lmss/m/n/10.95 m
+......\OT1/lmss/m/n/10.95 p
+......\OT1/lmss/m/n/10.95 l
+......\OT1/lmss/m/n/10.95 e
+......\OT1/lmss/m/n/10.95 ,
+......\glue 3.65 plus 2.28123 minus 0.97333
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 u
+......\OT1/lmss/m/n/10.95 b
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 e
+......\OT1/lmss/m/n/10.95 c
+......\OT1/lmss/m/n/10.95 t
+......\OT1/lmss/m/n/10.95 i
+......\OT1/lmss/m/n/10.95 o
+......\OT1/lmss/m/n/10.95 n
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 :
+......\glue 4.86665 plus 3.65 minus 0.60832
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 i
+......\OT1/lmss/m/n/10.95 m
+......\OT1/lmss/m/n/10.95 p
+......\OT1/lmss/m/n/10.95 l
+......\OT1/lmss/m/n/10.95 e
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\glue 0.0 plus 1.0fil
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {3}{1}{2}{10/10}{Subsection}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {10}{10}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 4.0
+...\hbox(7.9375+0.0)x307.28987
+....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+....\hbox(7.9375+0.0)x307.28987
+.....\vbox(7.9375+0.0)x307.28987
+......\hbox(7.9375+0.0)x307.28987
+.......\hbox(7.9375+0.0)x307.28987
+........\glue -28.45274
+........\hbox(7.9375+0.0)x364.19536
+.........\vbox(7.9375+0.0)x364.19536
+..........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+..........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+..........\hbox(7.9375+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\vbox(7.9375+0.0)x364.19536
+............\hbox(3.9375+0.0)x364.19536, glue set 352.00786fill
+.............\glue(\leftskip) 4.0
+.............\hbox(0.0+0.0)x0.0
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 0.0 plus 1.0fill
+.............\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.............\hbox(3.9375+0.0)x3.1875
+..............\glue 0.0 plus 1.0fil minus 1.0fil
+..............\OT1/lmss/m/n/6 3
+.............\pdfcolorstack 0 pop
+.............\penalty 10000
+.............\glue(\parfillskip) 0.0 plus 1.0fil
+.............\glue(\rightskip) 5.0
+............\glue 4.0
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+........\glue -28.45274
+.......\glue 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fil
+......\glue(\lineskip) 0.0
+......\hbox(0.0+0.0)x0.0
+.....\glue 0.0 plus 1.0fil
+....\pdfcolorstack 0 pop
+.\kern 0.0
+Completed box being shipped out [11]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\pdfdest name{Navigation11} xyz
+...\penalty 10000
+...\pdfdest name{page.11} xyz
+...\penalty 10000
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.98 g 0.98 G}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(261.20912+0.0)x307.28987
+....\write-{}
+....\write1{\@writefile{toc}{\protect \beamer@sectionintoc {4}{Section}{11}{0}{4}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@sectionpages {8}{10}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@subsectionpages {9}{10}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \sectionentry {4}{Section}{11}{Section}{0}}}}
+....\write5{\protect \BOOKMARK [2][]{Outline0.4}{\376\377\000S\000e\000c\000t\000i\000o\000n}{}% 7}
+....\pdfdest name{Outline0.4} xyz
+....\glue(\topskip) 0.0
+....\vbox(261.20912+0.0)x307.28987, glue set 111.00664fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\rule(0.0+0.0)x*
+.....\penalty 10000
+.....\glue 0.0
+.....\glue 0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\penalty -51
+.....\glue 9.0 plus 3.0 minus 5.0
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.00008+0.0)x307.28987, glue set 129.29518fil
+......\glue(\leftskip) 0.0 plus 1.0fil
+......\hbox(0.0+0.0)x0.0
+.......\glue 0.0
+.......\glue 0.0
+.......\glue -5.475
+.......\hbox(0.0+0.0)x0.0
+........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+........\pdfcolorstack 0 pop
+.......\glue 5.475
+......\penalty 0
+......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/N/C[.5 .5 .5]} action goto name{Navigation11}
+......\OT1/lmss/bx/n/14.4 S
+......\OT1/lmss/bx/n/14.4 e
+......\OT1/lmss/bx/n/14.4 c
+......\OT1/lmss/bx/n/14.4 t
+......\OT1/lmss/bx/n/14.4 i
+......\OT1/lmss/bx/n/14.4 o
+......\OT1/lmss/bx/n/14.4 n
+......\pdfendlink
+......\penalty 10000
+......\glue(\parfillskip) 0.0
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\baselineskip) 14.0
+.....\hbox(0.0+0.0)x307.28987, glue set 153.64494fil
+......\glue(\leftskip) 0.0 plus 1.0fil
+......\hbox(0.0+0.0)x0.0
+......\hbox(0.0+0.0)x0.0
+......\penalty 10000
+......\glue(\parfillskip) 0.0
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\penalty -51
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 pop
+.....\glue 9.0 plus 3.0 minus 5.0
+.....\glue 9.13327
+.....\glue 0.0
+.....\pdfcolorstack 0 pop
+.....\glue 0.0 plus 1.0fil
+.....\rule(0.0+0.0)x*
+.....\penalty 10000
+.....\glue -11.9375
+.....\glue 0.0
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {4}{0}{1}{11/11}{}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {11}{11}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 11.9375
+...\hbox(0.0+0.0)x307.28987
+....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+....\hbox(0.0+0.0)x307.28987, glue set 333.74261fil
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue 0.0 plus 1.0fil
+.....\hbox(0.0+0.0)x-26.45274
+......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+......\pdfcolorstack 0 push {0.6429 0.67427 0.68054 rg 0.6429 0.67427 0.68054 RG}
+......\pdfcolorstack 0 pop
+......\pdfcolorstack 0 pop
+......\glue -28.45274
+......\glue 2.0
+....\pdfcolorstack 0 pop
+....\pdfcolorstack 0 pop
+.\kern 0.0
+Completed box being shipped out [12]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\pdfdest name{Navigation12} xyz
+...\penalty 10000
+...\pdfdest name{page.12} xyz
+...\penalty 10000
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.98 g 0.98 G}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(261.20912+0.0)x307.28987
+....\write-{}
+....\write1{\@writefile{toc}{\protect \beamer@subsectionintoc {4}{1}{Subsection}{12}{0}{4}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@subsectionpages {11}{11}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@subsectionentry {0}{4}{1}{12}{Subsection}}}}
+....\write5{\protect \BOOKMARK [3][]{Outline0.4.1.12}{\376\377\000S\000u\000b\000s\000e\000c\000t\000i\000o\000n}{Outline0.4}% 8}
+....\pdfdest name{Outline0.4.1.12} xyz
+....\glue(\topskip) 0.0
+....\vbox(261.20912+0.0)x307.28987, glue set 111.00664fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\rule(0.0+0.0)x*
+.....\penalty 10000
+.....\glue 0.0
+.....\glue 0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\penalty -51
+.....\glue 9.0 plus 3.0 minus 5.0
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\hbox(10.00008+0.0)x307.28987, glue set 129.29518fil
+......\glue(\leftskip) 0.0 plus 1.0fil
+......\hbox(0.0+0.0)x0.0
+.......\glue 0.0
+.......\glue 0.0
+.......\glue -5.475
+.......\hbox(0.0+0.0)x0.0
+........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+........\pdfcolorstack 0 pop
+.......\glue 5.475
+......\penalty 0
+......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/N/C[.5 .5 .5]} action goto name{Navigation11}
+......\OT1/lmss/bx/n/14.4 S
+......\OT1/lmss/bx/n/14.4 e
+......\OT1/lmss/bx/n/14.4 c
+......\OT1/lmss/bx/n/14.4 t
+......\OT1/lmss/bx/n/14.4 i
+......\OT1/lmss/bx/n/14.4 o
+......\OT1/lmss/bx/n/14.4 n
+......\pdfendlink
+......\penalty 10000
+......\glue(\parfillskip) 0.0
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\baselineskip) 5.6666
+.....\hbox(8.3334+0.0)x307.28987, glue set 124.09029fil
+......\glue(\leftskip) 0.0 plus 1.0fil
+......\hbox(0.0+0.0)x0.0
+......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/N/C[.5 .5 .5]} action goto name{Navigation12}
+......\OT1/lmss/bx/n/12 S
+......\OT1/lmss/bx/n/12 u
+......\OT1/lmss/bx/n/12 b
+......\OT1/lmss/bx/n/12 s
+......\OT1/lmss/bx/n/12 e
+......\OT1/lmss/bx/n/12 c
+......\OT1/lmss/bx/n/12 t
+......\OT1/lmss/bx/n/12 i
+......\OT1/lmss/bx/n/12 o
+......\OT1/lmss/bx/n/12 n
+......\pdfendlink
+......\penalty 10000
+......\glue(\parfillskip) 0.0
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\penalty -51
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 pop
+.....\glue 9.0 plus 3.0 minus 5.0
+.....\glue 9.13327
+.....\glue 0.0
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 pop
+.....\glue 0.0 plus 1.0fil
+.....\rule(0.0+0.0)x*
+.....\penalty 10000
+.....\glue -11.9375
+.....\glue 0.0
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {4}{1}{1}{12/12}{Subsection}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {12}{12}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 11.9375
+...\hbox(0.0+0.0)x307.28987
+....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+....\hbox(0.0+0.0)x307.28987, glue set 333.74261fil
+.....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.....\glue 0.0 plus 1.0fil
+.....\hbox(0.0+0.0)x-26.45274
+......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+......\pdfcolorstack 0 push {0.6429 0.67427 0.68054 rg 0.6429 0.67427 0.68054 RG}
+......\pdfcolorstack 0 pop
+......\pdfcolorstack 0 pop
+......\glue -28.45274
+......\glue 2.0
+....\pdfcolorstack 0 pop
+....\pdfcolorstack 0 pop
+.\kern 0.0
+\tf@nav=\write...
+\tf@toc=\write...
+\tf@snm=\write...
+(sectionpages.aux)
+Package rerunfilecheck Info: File `sectionpages.out' has not changed.
+(rerunfilecheck)             Checksum: D2931E9029CD1D0FCD374E2E4118FE51;741.

--- a/testfiles/sectionpages.tlg
+++ b/testfiles/sectionpages.tlg
@@ -339,7 +339,7 @@ Completed box being shipped out [3]
 ....\write5{\protect \BOOKMARK [2][]{Outline0.1}{\376\377\000S\000e\000c\000t\000i\000o\000n}{}% 1}
 ....\pdfdest name{Outline0.1} xyz
 ....\glue(\topskip) 0.0
-....\vbox(261.20912+0.0)x307.28987, glue set 120.07327fil
+....\vbox(261.20912+0.0)x307.28987, glue set 117.97325fil
 .....\penalty 10000
 .....\vbox(0.0+0.0)x0.0
 .....\penalty 10000
@@ -358,11 +358,11 @@ Completed box being shipped out [3]
 .....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\hbox(19.23753+13.76254)x307.28987, glue set 32.64862fil
+.....\hbox(21.33755+15.86256)x307.28987, glue set 32.64862fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
 ......\mathon
-......\vbox(19.23753+13.76254)x241.99265
+......\vbox(21.33755+15.86256)x241.99265
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .......\glue(\parskip) 0.0
 .......\glue(\parskip) 0.0
@@ -438,10 +438,10 @@ Completed box being shipped out [3]
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .......\glue(\parskip) 0.0
 .......\glue(\parskip) 0.0
-.......\glue(\baselineskip) 14.0
-.......\hbox(0.0+0.0)x241.99265, glue set 120.99632fil
+.......\glue(\baselineskip) 4.20004
+.......\hbox(9.79996+4.20004)x241.99265, glue set 120.99632fil
 ........\hbox(0.0+0.0)x0.0
-........\hbox(0.0+0.0)x0.0
+........\rule(9.79996+4.20004)x0.0
 ........\penalty 10000
 ........\glue(\parfillskip) 0.0 plus 1.0fil
 ........\glue(\rightskip) 0.0 plus 1.0fil
@@ -551,7 +551,7 @@ Completed box being shipped out [4]
 ....\write5{\protect \BOOKMARK [3][]{Outline0.1.1.4}{\376\377\000S\000u\000b\000s\000e\000c\000t\000i\000o\000n}{Outline0.1}% 2}
 ....\pdfdest name{Outline0.1.1.4} xyz
 ....\glue(\topskip) 0.0
-....\vbox(261.20912+0.0)x307.28987, glue set 120.07327fil
+....\vbox(261.20912+0.0)x307.28987, glue set 117.97325fil
 .....\penalty 10000
 .....\vbox(0.0+0.0)x0.0
 .....\penalty 10000
@@ -571,11 +571,11 @@ Completed box being shipped out [4]
 .....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\hbox(19.23753+13.76254)x307.28987, glue set 32.64862fil
+.....\hbox(21.33755+15.86256)x307.28987, glue set 32.64862fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
 ......\mathon
-......\vbox(19.23753+13.76254)x241.99265
+......\vbox(21.33755+15.86256)x241.99265
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .......\glue(\parskip) 0.0
 .......\glue(\parskip) 0.0
@@ -651,9 +651,10 @@ Completed box being shipped out [4]
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .......\glue(\parskip) 0.0
 .......\glue(\parskip) 0.0
-.......\glue(\baselineskip) 5.6666
-.......\hbox(8.3334+0.0)x241.99265, glue set 91.44168fil
+.......\glue(\baselineskip) 4.20004
+.......\hbox(9.79996+4.20004)x241.99265, glue set 91.44168fil
 ........\hbox(0.0+0.0)x0.0
+........\rule(9.79996+4.20004)x0.0
 ........\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/N/C[.5 .5 .5]} action goto name{Navigation4}
 ........\OT1/lmss/bx/n/12 S
 ........\OT1/lmss/bx/n/12 u
@@ -1017,7 +1018,7 @@ Completed box being shipped out [6]
 ....\write5{\protect \BOOKMARK [2][]{Outline0.2}{\376\377\000S\000e\000c\000t\000i\000o\000n}{}% 3}
 ....\pdfdest name{Outline0.2} xyz
 ....\glue(\topskip) 0.0
-....\vbox(261.20912+0.0)x307.28987, glue set 120.07327fil
+....\vbox(261.20912+0.0)x307.28987, glue set 117.97325fil
 .....\penalty 10000
 .....\vbox(0.0+0.0)x0.0
 .....\penalty 10000
@@ -1036,11 +1037,11 @@ Completed box being shipped out [6]
 .....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\hbox(19.23753+13.76254)x307.28987, glue set 32.64862fil
+.....\hbox(21.33755+15.86256)x307.28987, glue set 32.64862fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
 ......\mathon
-......\vbox(19.23753+13.76254)x241.99265
+......\vbox(21.33755+15.86256)x241.99265
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .......\glue(\parskip) 0.0
 .......\glue(\parskip) 0.0
@@ -1116,10 +1117,10 @@ Completed box being shipped out [6]
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .......\glue(\parskip) 0.0
 .......\glue(\parskip) 0.0
-.......\glue(\baselineskip) 14.0
-.......\hbox(0.0+0.0)x241.99265, glue set 120.99632fil
+.......\glue(\baselineskip) 4.20004
+.......\hbox(9.79996+4.20004)x241.99265, glue set 120.99632fil
 ........\hbox(0.0+0.0)x0.0
-........\hbox(0.0+0.0)x0.0
+........\rule(9.79996+4.20004)x0.0
 ........\penalty 10000
 ........\glue(\parfillskip) 0.0 plus 1.0fil
 ........\glue(\rightskip) 0.0 plus 1.0fil
@@ -1229,7 +1230,7 @@ Completed box being shipped out [7]
 ....\write5{\protect \BOOKMARK [3][]{Outline0.2.1.7}{\376\377\000S\000u\000b\000s\000e\000c\000t\000i\000o\000n}{Outline0.2}% 4}
 ....\pdfdest name{Outline0.2.1.7} xyz
 ....\glue(\topskip) 0.0
-....\vbox(261.20912+0.0)x307.28987, glue set 111.00664fil
+....\vbox(261.20912+0.0)x307.28987, glue set 108.90662fil
 .....\penalty 10000
 .....\vbox(0.0+0.0)x0.0
 .....\penalty 10000
@@ -1278,10 +1279,11 @@ Completed box being shipped out [7]
 .....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\glue(\baselineskip) 5.6666
-.....\hbox(8.3334+0.0)x307.28987, glue set 124.09029fil
+.....\glue(\baselineskip) 4.20004
+.....\hbox(9.79996+4.20004)x307.28987, glue set 124.09029fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
+......\rule(9.79996+4.20004)x0.0
 ......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/N/C[.5 .5 .5]} action goto name{Navigation7}
 ......\OT1/lmss/bx/n/12 S
 ......\OT1/lmss/bx/n/12 u
@@ -1405,7 +1407,7 @@ Completed box being shipped out [8]
 ....\write5{\protect \BOOKMARK [2][]{Outline0.3}{\376\377\000S\000e\000c\000t\000i\000o\000n}{}% 5}
 ....\pdfdest name{Outline0.3} xyz
 ....\glue(\topskip) 0.0
-....\vbox(261.20912+0.0)x307.28987, glue set 120.07327fil
+....\vbox(261.20912+0.0)x307.28987, glue set 117.97325fil
 .....\penalty 10000
 .....\vbox(0.0+0.0)x0.0
 .....\penalty 10000
@@ -1424,11 +1426,11 @@ Completed box being shipped out [8]
 .....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\hbox(19.23753+13.76254)x307.28987, glue set 32.64862fil
+.....\hbox(21.33755+15.86256)x307.28987, glue set 32.64862fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
 ......\mathon
-......\vbox(19.23753+13.76254)x241.99265
+......\vbox(21.33755+15.86256)x241.99265
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .......\glue(\parskip) 0.0
 .......\glue(\parskip) 0.0
@@ -1504,10 +1506,10 @@ Completed box being shipped out [8]
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .......\glue(\parskip) 0.0
 .......\glue(\parskip) 0.0
-.......\glue(\baselineskip) 14.0
-.......\hbox(0.0+0.0)x241.99265, glue set 120.99632fil
+.......\glue(\baselineskip) 4.20004
+.......\hbox(9.79996+4.20004)x241.99265, glue set 120.99632fil
 ........\hbox(0.0+0.0)x0.0
-........\hbox(0.0+0.0)x0.0
+........\rule(9.79996+4.20004)x0.0
 ........\penalty 10000
 ........\glue(\parfillskip) 0.0 plus 1.0fil
 ........\glue(\rightskip) 0.0 plus 1.0fil
@@ -1617,7 +1619,7 @@ Completed box being shipped out [9]
 ....\write5{\protect \BOOKMARK [3][]{Outline0.3.1.9}{\376\377\000S\000u\000b\000s\000e\000c\000t\000i\000o\000n}{Outline0.3}% 6}
 ....\pdfdest name{Outline0.3.1.9} xyz
 ....\glue(\topskip) 0.0
-....\vbox(261.20912+0.0)x307.28987, glue set 120.07327fil
+....\vbox(261.20912+0.0)x307.28987, glue set 117.97325fil
 .....\penalty 10000
 .....\vbox(0.0+0.0)x0.0
 .....\penalty 10000
@@ -1637,11 +1639,11 @@ Completed box being shipped out [9]
 .....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\hbox(19.23753+13.76254)x307.28987, glue set 32.64862fil
+.....\hbox(21.33755+15.86256)x307.28987, glue set 32.64862fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
 ......\mathon
-......\vbox(19.23753+13.76254)x241.99265
+......\vbox(21.33755+15.86256)x241.99265
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .......\glue(\parskip) 0.0
 .......\glue(\parskip) 0.0
@@ -1717,9 +1719,10 @@ Completed box being shipped out [9]
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .......\glue(\parskip) 0.0
 .......\glue(\parskip) 0.0
-.......\glue(\baselineskip) 5.6666
-.......\hbox(8.3334+0.0)x241.99265, glue set 91.44168fil
+.......\glue(\baselineskip) 4.20004
+.......\hbox(9.79996+4.20004)x241.99265, glue set 91.44168fil
 ........\hbox(0.0+0.0)x0.0
+........\rule(9.79996+4.20004)x0.0
 ........\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/N/C[.5 .5 .5]} action goto name{Navigation9}
 ........\OT1/lmss/bx/n/12 S
 ........\OT1/lmss/bx/n/12 u
@@ -2076,7 +2079,7 @@ Completed box being shipped out [11]
 ....\write5{\protect \BOOKMARK [2][]{Outline0.4}{\376\377\000S\000e\000c\000t\000i\000o\000n}{}% 7}
 ....\pdfdest name{Outline0.4} xyz
 ....\glue(\topskip) 0.0
-....\vbox(261.20912+0.0)x307.28987, glue set 111.00664fil
+....\vbox(261.20912+0.0)x307.28987, glue set 108.90662fil
 .....\penalty 10000
 .....\vbox(0.0+0.0)x0.0
 .....\penalty 10000
@@ -2124,11 +2127,11 @@ Completed box being shipped out [11]
 .....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\glue(\baselineskip) 14.0
-.....\hbox(0.0+0.0)x307.28987, glue set 153.64494fil
+.....\glue(\baselineskip) 4.20004
+.....\hbox(9.79996+4.20004)x307.28987, glue set 153.64494fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
-......\hbox(0.0+0.0)x0.0
+......\rule(9.79996+4.20004)x0.0
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0
 ......\glue(\rightskip) 0.0 plus 1.0fil
@@ -2238,7 +2241,7 @@ Completed box being shipped out [12]
 ....\write5{\protect \BOOKMARK [3][]{Outline0.4.1.12}{\376\377\000S\000u\000b\000s\000e\000c\000t\000i\000o\000n}{Outline0.4}% 8}
 ....\pdfdest name{Outline0.4.1.12} xyz
 ....\glue(\topskip) 0.0
-....\vbox(261.20912+0.0)x307.28987, glue set 111.00664fil
+....\vbox(261.20912+0.0)x307.28987, glue set 108.90662fil
 .....\penalty 10000
 .....\vbox(0.0+0.0)x0.0
 .....\penalty 10000
@@ -2287,10 +2290,11 @@ Completed box being shipped out [12]
 .....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\glue(\baselineskip) 5.6666
-.....\hbox(8.3334+0.0)x307.28987, glue set 124.09029fil
+.....\glue(\baselineskip) 4.20004
+.....\hbox(9.79996+4.20004)x307.28987, glue set 124.09029fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
+......\rule(9.79996+4.20004)x0.0
 ......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/N/C[.5 .5 .5]} action goto name{Navigation12}
 ......\OT1/lmss/bx/n/12 S
 ......\OT1/lmss/bx/n/12 u

--- a/testfiles/support/sectionpages.tex
+++ b/testfiles/support/sectionpages.tex
@@ -1,0 +1,54 @@
+\input regression-test
+
+\documentclass{beamer}
+\usetheme{moloch}
+\usepackage{lmodern}
+
+\begin{document}
+
+\maketitle
+
+\START
+\showoutput
+
+\begin{frame}[c]
+  Sections: progressbar, subsections: progressbar
+\end{frame}
+
+\molochset{sectionpage=progressbar}
+\molochset{subsectionpage=progressbar}
+
+\section{Section}
+\subsection{Subsection}
+
+\begin{frame}[c]
+  Sections: progressbar, subsections: simple
+\end{frame}
+
+\molochset{sectionpage=progressbar}
+
+\section{Section}
+
+\molochset{subsectionpage=simple}
+
+\subsection{Subsection}
+
+\molochset{subsectionpage=progressbar}
+\molochset{sectionpage=progressbar}
+
+\section{Section}
+\subsection{Subsection}
+
+\begin{frame}[c]
+  Sections: simple, subsections: simple
+\end{frame}
+
+\molochset{sectionpage=simple}
+\molochset{subsectionpage=simple}
+
+\section{Section}
+\subsection{Subsection}
+
+% \END
+
+\end{document}

--- a/testfiles/test.tlg
+++ b/testfiles/test.tlg
@@ -348,7 +348,7 @@ Completed box being shipped out [2]
 ....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@subsectionpages {1}{1}}}}
 ....\write1{\@writefile{nav}{\protect \headcommand {\protect \sectionentry {1}{Results}{2}{Results}{0}}}}
 ....\glue(\topskip) 0.0
-....\vbox(261.20912+0.0)x307.28987, glue set 119.07327fil
+....\vbox(261.20912+0.0)x307.28987, glue set 120.07327fil
 .....\penalty 10000
 .....\vbox(0.0+0.0)x0.0
 .....\penalty 10000
@@ -367,11 +367,11 @@ Completed box being shipped out [2]
 .....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\hbox(13.43753+7.96255)x307.28987, glue set 32.64862fil
+.....\hbox(19.23753+13.76254)x307.28987, glue set 32.64862fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
 ......\mathon
-......\vbox(13.43753+7.96255)x241.99265
+......\vbox(19.23753+13.76254)x241.99265
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .......\glue(\parskip) 0.0
 .......\glue(\parskip) 0.0
@@ -388,7 +388,7 @@ Completed box being shipped out [2]
 ........\glue(\parfillskip) 0.0 plus 1.0fil
 ........\glue(\rightskip) 0.0 plus 1.0fil
 .......\glue 0.0
-.......\glue -6.59999
+.......\glue -9.0
 .......\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
 .......\glue(\parskip) 0.0
 .......\glue(\parskip) 0.0
@@ -442,13 +442,22 @@ Completed box being shipped out [2]
 ........\penalty 10000
 ........\glue(\parfillskip) 0.0 plus 1.0fil
 ........\glue(\rightskip) 0.0 plus 1.0fil
+.......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 14.0
+.......\hbox(0.0+0.0)x241.99265, glue set 120.99632fil
+........\hbox(0.0+0.0)x0.0
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0 plus 1.0fil
+.......\pdfcolorstack 0 pop
 .......\pdfcolorstack 0 pop
 ......\mathoff
 ......\penalty 10000
 ......\glue(\parfillskip) 0.0
 ......\glue(\rightskip) 0.0 plus 1.0fil
-.....\glue 13.6
-.....\glue 0.0
 .....\pdfcolorstack 0 pop
 .....\glue 0.0 plus 1.0fil
 .....\rule(0.0+0.0)x*

--- a/testfiles/test.tlg
+++ b/testfiles/test.tlg
@@ -348,7 +348,7 @@ Completed box being shipped out [2]
 ....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@subsectionpages {1}{1}}}}
 ....\write1{\@writefile{nav}{\protect \headcommand {\protect \sectionentry {1}{Results}{2}{Results}{0}}}}
 ....\glue(\topskip) 0.0
-....\vbox(261.20912+0.0)x307.28987, glue set 120.07327fil
+....\vbox(261.20912+0.0)x307.28987, glue set 117.97325fil
 .....\penalty 10000
 .....\vbox(0.0+0.0)x0.0
 .....\penalty 10000
@@ -367,11 +367,11 @@ Completed box being shipped out [2]
 .....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .....\glue(\parskip) 0.0
 .....\glue(\parskip) 0.0
-.....\hbox(19.23753+13.76254)x307.28987, glue set 32.64862fil
+.....\hbox(21.33755+15.86256)x307.28987, glue set 32.64862fil
 ......\glue(\leftskip) 0.0 plus 1.0fil
 ......\hbox(0.0+0.0)x0.0
 ......\mathon
-......\vbox(19.23753+13.76254)x241.99265
+......\vbox(21.33755+15.86256)x241.99265
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .......\glue(\parskip) 0.0
 .......\glue(\parskip) 0.0
@@ -445,10 +445,10 @@ Completed box being shipped out [2]
 .......\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 .......\glue(\parskip) 0.0
 .......\glue(\parskip) 0.0
-.......\glue(\baselineskip) 14.0
-.......\hbox(0.0+0.0)x241.99265, glue set 120.99632fil
+.......\glue(\baselineskip) 4.20004
+.......\hbox(9.79996+4.20004)x241.99265, glue set 120.99632fil
 ........\hbox(0.0+0.0)x0.0
-........\hbox(0.0+0.0)x0.0
+........\rule(9.79996+4.20004)x0.0
 ........\penalty 10000
 ........\glue(\parfillskip) 0.0 plus 1.0fil
 ........\glue(\rightskip) 0.0 plus 1.0fil


### PR DESCRIPTION
Section pages with `sectionpage=simple` have the section title vertically centered in the frame. But, those with `sectionpage=progressbar` (the default) do not. This commit corrects that.