### PR TITLE
feat: redesign itemize environment

### DIFF
--- a/src/beamerinnerthememoloch.dtx
+++ b/src/beamerinnerthememoloch.dtx
@@ -443,10 +443,11 @@
 %
 %    \begin{macrocode}
 \setbeamertemplate{itemize item}[circle]
-\setbeamertemplate{itemize subitem}{%
-  \usebeamerfont*{itemize subitem}\raise1pt\hbox{\donotcoloroutermaths$\circ$}%
+\setbeamertemplate{itemize subitem}{\raise1.5pt\hbox{\vrule width 0.8ex height 0.8ex}}
+\setbeamerfont{itemize subsubitem}{size=\tiny}
+\setbeamertemplate{itemize subsubitem}{%
+  \usebeamerfont*{itemize subsubitem}\raise1.75pt\hbox{\donotcoloroutermaths$\blacktriangleright$}%
 }
-\setbeamertemplate{itemize subsubitem}{\textbullet}
 \setbeamertemplate{caption label separator}{: }
 \setbeamertemplate{caption}[numbered]
 %    \end{macrocode}

--- a/testfiles/test.tlg
+++ b/testfiles/test.tlg
@@ -2349,18 +2349,9 @@ Completed box being shipped out [6]
 ....\pdfcolorstack 0 pop
 .\kern 0.0
 LaTeX Font Info:    External font `lmex10' loaded for size
-(Font)              <10> on input line ....
-LaTeX Font Info:    External font `lmex10' loaded for size
-(Font)              <7> on input line ....
-LaTeX Font Info:    External font `lmex10' loaded for size
 (Font)              <5> on input line ....
-LaTeX Font Info:    Font shape `OT1/lmss/m/it' in size <10> not available
-(Font)              Font shape `OT1/lmss/m/sl' tried instead on input line ....
-LaTeX Font Info:    Font shape `OT1/lmss/m/it' in size <7> not available
-(Font)              Font shape `OT1/lmss/m/sl' tried instead on input line ....
 LaTeX Font Info:    Font shape `OT1/lmss/m/it' in size <5> not available
 (Font)              Font shape `OT1/lmss/m/sl' tried instead on input line ....
-LaTeX Font Info:    Trying to load font information for TS1+lmss on input line ....
 Completed box being shipped out [7]
 \vbox(200.87663+0.0)x263.47263
 .\hbox(0.0+0.0)x0.0
@@ -2610,20 +2601,18 @@ Completed box being shipped out [7]
 .......\glue(\parskip) 0.0
 .......\glue(\baselineskip) 4.0555
 .......\hbox(6.9445+0.0)x57.60611, glue set 13.40057fil, shifted 43.80011
-........\hbox(5.44444+0.0)x0.0
+........\hbox(5.0556+0.0)x0.0
 .........\glue 0.0
 .........\glue -16.42505
 .........\glue -5.475
-.........\hbox(5.44444+0.0)x16.42505, glue set 16.42505fil
+.........\hbox(5.0556+0.0)x16.42505, glue set 16.42505fil
 ..........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\hbox(5.44444+0.0)x0.0, glue set - 5.00002fil
+..........\hbox(5.0556+0.0)x0.0, glue set - 3.5556fil
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-...........\hbox(4.44444+0.0)x5.00002, shifted -1.0
-............\mathon
-............\OMS/lmsy/m/n/10 ^^N
-............\mathoff
+...........\hbox(3.5556+0.0)x3.5556, shifted -1.5
+............\rule(3.5556+*)x3.5556
 ...........\pdfcolorstack 0 pop
 ..........\pdfcolorstack 0 pop
 .........\glue 5.475
@@ -2645,17 +2634,20 @@ Completed box being shipped out [7]
 .......\glue(\parskip) 0.0
 .......\glue(\baselineskip) 4.75
 .......\hbox(6.25+0.0)x35.70605, glue set 8.15077fil, shifted 65.70016
-........\hbox(3.58199+0.0)x0.0
+........\hbox(5.14368+0.0)x0.0
 .........\glue 0.0
 .........\glue -16.42505
 .........\glue -5.475
-.........\hbox(3.58199+0.0)x16.42505, glue set 16.42505fil
+.........\hbox(5.14368+0.0)x16.42505, glue set 16.42505fil
 ..........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\hbox(3.58199+0.0)x0.0, glue set - 7.19449fil
+..........\hbox(5.14368+0.0)x0.0, glue set - 5.35716fil
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-...........\TS1/lmss/m/n/9 ^^88
+...........\hbox(3.39368+0.45404)x5.35716, shifted -1.75
+............\mathon
+............\U/msa/m/n/6 I
+............\mathoff
 ...........\pdfcolorstack 0 pop
 ..........\pdfcolorstack 0 pop
 .........\glue 5.475
@@ -2686,17 +2678,20 @@ Completed box being shipped out [7]
 .......\glue(\parskip) 0.0
 .......\glue(\baselineskip) 3.0
 .......\hbox(6.25+0.0)x35.70605, glue set 6.25943fil, shifted 65.70016
-........\hbox(3.58199+0.0)x0.0
+........\hbox(5.14368+0.0)x0.0
 .........\glue 0.0
 .........\glue -16.42505
 .........\glue -5.475
-.........\hbox(3.58199+0.0)x16.42505, glue set 16.42505fil
+.........\hbox(5.14368+0.0)x16.42505, glue set 16.42505fil
 ..........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\hbox(3.58199+0.0)x0.0, glue set - 7.19449fil
+..........\hbox(5.14368+0.0)x0.0, glue set - 5.35716fil
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-...........\TS1/lmss/m/n/9 ^^88
+...........\hbox(3.39368+0.45404)x5.35716, shifted -1.75
+............\mathon
+............\U/msa/m/n/6 I
+............\mathoff
 ...........\pdfcolorstack 0 pop
 ..........\pdfcolorstack 0 pop
 .........\glue 5.475


### PR DESCRIPTION
I'm not sure about the current style of the itemize environment. This is an attempt to improve upon it. It is perhaps slightly more rational, at least to me, using filled markers everywhere. I have not changed `item` but

- `subitem` is changed to a filled square
- `subsubitem` is changed to a filled triangle

Most of the suggestiosn are taken from the beamer definitions. Note that there is an obvious problem with the alignment of the subsubitem in the current (old) approach, which should be fixed in any case.

I'm very open for suggestions here, so please let me know what you would prefer!

Here's a side-by-side comparison:

![image](https://github.com/user-attachments/assets/b1c9a25a-55a1-45cb-b045-cf7de4dcfad4)

Here's the code to generate it if you'd like to play with it.

```tex
\documentclass{beamer}

\usetheme{moloch}

\newcommand{\shoppinglist}{%
  \begin{itemize}
    \item Potatoes
          \begin{itemize}
            \item Something
                  \begin{itemize}
                    \item Something
                  \end{itemize}
          \end{itemize}
    \item Carrots
  \end{itemize}
}

\begin{document}

\begin{frame}
  \begin{columns}

    % This is the proposed new style (this PR)
    \setbeamertemplate{itemize item}[circle]
    \setbeamertemplate{itemize subitem}{\raise1.5pt\hbox{\vrule width 0.8ex height 0.8ex}}
    \setbeamerfont{itemize subsubitem}{size=\tiny}
    \setbeamertemplate{itemize subsubitem}{%
      \usebeamerfont*{itemize subsubitem}\raise1.75pt\hbox{\donotcoloroutermaths$\blacktriangleright$}%
    }

    \begin{column}{0.45\textwidth}
      \begin{block}{New}
        \shoppinglist
      \end{block}
    \end{column}

    % This is the old style (main branch)
    \setbeamertemplate{itemize item}[circle]
    \setbeamertemplate{itemize subitem}{%
      \usebeamerfont*{itemize subitem}\raise1pt\hbox{\donotcoloroutermaths$\circ$}%
    }
    \setbeamertemplate{itemize subsubitem}{\textbullet}

    \begin{column}{0.45\textwidth}
      \begin{block}{Old}
        \shoppinglist
      \end{block}
    \end{column}
  \end{columns}

\end{frame}

\end{document}

```