### PR TITLE
feat: draw all itemize symbols manually

### DIFF
--- a/src/beamerinnerthememoloch.dtx
+++ b/src/beamerinnerthememoloch.dtx
@@ -441,13 +441,62 @@
 %
 % \subsubsection{Lists and Floats}
 %
+% Moloch uses custom symbols for the |itemize| environment. The symbols
+% are defined as below, using |pgf| commands to draw the shapes.
+% This is slightly different than what beamer does by default, which is
+% to use font glyphs from the math font. But we want to avoid
+% this reliance on the math font, which may have somewhat
+% surprising side effects.
+%
+% By default, we use a filled circle for the first-level |itemize| items,
+% a filled square for the second level, and a filled triangle for
+% the third level. Since the triangle tapers to a point, we add a slight
+% overhang to it so that it visually aligns better with the other symbols.
+% We do the same for the circle, but to a lower extent.
+%
 %    \begin{macrocode}
-\setbeamertemplate{itemize item}[circle]
-\setbeamertemplate{itemize subitem}{\raise1.5pt\hbox{\vrule width 0.8ex height 0.8ex}}
-\setbeamerfont{itemize subsubitem}{size=\tiny}
-\setbeamertemplate{itemize subsubitem}{%
-  \usebeamerfont*{itemize subsubitem}\raise1.75pt\hbox{\donotcoloroutermaths$\blacktriangleright$}%
+\newcommand{\mitemover}[2]{\makebox[0pt][r]{#1}\kern-#2}
+\newcommand{\mitem}[1]{\mitemover{#1}{0pt}}
+
+\newcommand{\overhangSquare}{0pt}
+\newcommand{\overhangCircle}{0.05ex}
+\newcommand{\overhangTriangle}{0.25ex}
+
+\newcommand{\moloch@circle}{
+  \begin{pgfpicture}
+    \pgfsetbaseline{-0.7ex}
+    \pgfpathcircle{\pgfpoint{0}{0}}{0.16em}
+    \pgfusepath{fill}
+  \end{pgfpicture}%
 }
+%
+\newcommand{\moloch@square}{
+  \begin{pgfpicture}
+    \pgfsetbaseline{-0.7ex}
+    \pgfpathrectangle{\pgfpoint{-0.165em}{-0.165em}}{\pgfpoint{0.31em}{0.31em}}
+    \pgfusepath{fill}
+  \end{pgfpicture}%
+}
+%
+\newcommand{\moloch@triangle}{
+  \begin{pgfpicture}
+    \pgfsetbaseline{-0.7ex}
+    \pgfpathmoveto{\pgfpoint{0.21em}{0}}       % right vertex (tip)
+    \pgfpathlineto{\pgfpoint{-0.21em}{0.21em}}  % top left
+    \pgfpathlineto{\pgfpoint{-0.21em}{-0.21em}} % bottom left
+    \pgfpathclose
+    \pgfusepath{fill}
+  \end{pgfpicture}%
+}
+%    \end{macrocode}
+%
+%    Next, we set the itemize templates to use these symbols.
+%
+%    \begin{macrocode}
+% \setbeamertemplate{itemize item}[circle]
+\setbeamertemplate{itemize item}{\mitemover{\moloch@circle}{\overhangCircle}}
+\setbeamertemplate{itemize subitem}{\mitemover{\moloch@square}{\overhangSquare}}
+\setbeamertemplate{itemize subsubitem}{\mitemover{\moloch@triangle}{\overhangTriangle}}
 \setbeamertemplate{caption label separator}{: }
 \setbeamertemplate{caption}[numbered]
 %    \end{macrocode}

--- a/testfiles/test.tlg
+++ b/testfiles/test.tlg
@@ -2353,10 +2353,6 @@ Completed box being shipped out [6]
 .....\glue 0.0 plus 1.0fil
 ....\pdfcolorstack 0 pop
 .\kern 0.0
-LaTeX Font Info:    External font `lmex10' loaded for size
-(Font)              <5> on input line ....
-LaTeX Font Info:    Font shape `OT1/lmss/m/it' in size <5> not available
-(Font)              Font shape `OT1/lmss/m/sl' tried instead on input line ....
 Completed box being shipped out [7]
 \vbox(200.87663+0.0)x263.47263
 .\hbox(0.0+0.0)x0.0
@@ -2572,20 +2568,42 @@ Completed box being shipped out [7]
 .......\glue(\parskip) 0.0
 .......\glue(\baselineskip) 4.39578
 .......\hbox(7.60422+0.0)x79.50616, glue set 26.0655fil, shifted 21.90005
-........\hbox(6.11667+0.0)x0.0
+........\hbox(5.15872+0.0)x0.0
 .........\glue 0.0
 .........\glue -16.42505
 .........\glue -5.475
-.........\hbox(6.11667+0.0)x16.42505, glue set 16.42505fil
+.........\hbox(5.15872+0.0)x16.42505, glue set 16.42505fil
 ..........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\hbox(6.11667+0.0)x0.0, glue set - 5.475fil
+..........\hbox(5.15872+0.0)x0.0, glue set 0.24335fil
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-...........\hbox(4.86667+0.0)x5.475, shifted -1.25
-............\mathon
-............\OMS/lmsy/m/n/10.95 ^^O
-............\mathoff
+...........\hbox(5.15872+0.0)x0.0, glue set - 7.15405fil
+............\glue 0.0 plus 1.0fil minus 1.0fil
+............\glue 3.65 plus 1.825 minus 1.21666
+............\hbox(3.50406+0.0)x3.50406, shifted -1.65466
+.............\glue 1.75203
+.............\hbox(0.0+0.0)x0.0, shifted -1.75203
+..............\pdfliteral{q }
+..............\pdfliteral{0.13725 0.2157 0.23137 RG }
+..............\pdfliteral{0.13725 0.2157 0.23137 rg }
+..............\pdfliteral{0.3985 w }
+..............\hbox(0.0+0.0)x0.0
+...............\glue 0.0
+...............\glue 0.0
+...............\pdfliteral{1.7455 0.0 m }
+...............\pdfliteral{1.7455 0.964 0.964 1.7455 0.0 1.7455 c }
+...............\pdfliteral{-0.964 1.7455 -1.7455 0.964 -1.7455 0.0 c }
+...............\pdfliteral{-1.7455 -0.964 -0.964 -1.7455 0.0 -1.7455 c }
+...............\pdfliteral{0.964 -1.7455 1.7455 -0.964 1.7455 0.0 c }
+...............\pdfliteral{h }
+...............\pdfliteral{0.0 0.0 m }
+...............\pdfliteral{f }
+...............\glue 0.0 plus 1.0fil minus 1.0fil
+..............\pdfliteral{n }
+..............\pdfliteral{Q }
+..............\glue 0.0 plus 1.0fil minus 1.0fil
+...........\kern -0.24335
 ...........\pdfcolorstack 0 pop
 ..........\pdfcolorstack 0 pop
 .........\glue 5.475
@@ -2607,18 +2625,36 @@ Completed box being shipped out [7]
 .......\glue(\parskip) 0.0
 .......\glue(\baselineskip) 4.0555
 .......\hbox(6.9445+0.0)x57.60611, glue set 13.40057fil, shifted 43.80011
-........\hbox(5.0556+0.0)x0.0
+........\hbox(4.56117+0.0)x0.0
 .........\glue 0.0
 .........\glue -16.42505
 .........\glue -5.475
-.........\hbox(5.0556+0.0)x16.42505, glue set 16.42505fil
+.........\hbox(4.56117+0.0)x16.42505, glue set 16.42505fil
 ..........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\hbox(5.0556+0.0)x0.0, glue set - 3.5556fil
+..........\hbox(4.56117+0.0)x0.0
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-...........\hbox(3.5556+0.0)x3.5556, shifted -1.5
-............\rule(3.5556+*)x3.5556
+...........\hbox(4.56117+0.0)x0.0, glue set - 6.4333fil
+............\glue 0.0 plus 1.0fil minus 1.0fil
+............\glue 3.33333 plus 1.66666 minus 1.11111
+............\hbox(3.09998+0.0)x3.09998, shifted -1.4612
+.............\glue 1.64993
+.............\hbox(0.0+0.0)x0.0, shifted -1.64993
+..............\pdfliteral{q }
+..............\pdfliteral{0.13725 0.2157 0.23137 RG }
+..............\pdfliteral{0.13725 0.2157 0.23137 rg }
+..............\pdfliteral{0.3985 w }
+..............\hbox(0.0+0.0)x0.0
+...............\glue 0.0
+...............\glue 0.0
+...............\pdfliteral{-1.64378 -1.64378 3.08842 3.08842 re }
+...............\pdfliteral{f }
+...............\glue 0.0 plus 1.0fil minus 1.0fil
+..............\pdfliteral{n }
+..............\pdfliteral{Q }
+..............\glue 0.0 plus 1.0fil minus 1.0fil
+...........\kern 0.0
 ...........\pdfcolorstack 0 pop
 ..........\pdfcolorstack 0 pop
 .........\glue 5.475
@@ -2640,20 +2676,41 @@ Completed box being shipped out [7]
 .......\glue(\parskip) 0.0
 .......\glue(\baselineskip) 4.75
 .......\hbox(6.25+0.0)x35.70605, glue set 8.15077fil, shifted 65.70016
-........\hbox(5.14368+0.0)x0.0
+........\hbox(4.74252+0.0)x0.0
 .........\glue 0.0
 .........\glue -16.42505
 .........\glue -5.475
-.........\hbox(5.14368+0.0)x16.42505, glue set 16.42505fil
+.........\hbox(4.74252+0.0)x16.42505, glue set 16.42505fil
 ..........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\hbox(5.14368+0.0)x0.0, glue set - 5.35716fil
+..........\hbox(4.74252+0.0)x0.0, glue set 1.0fil
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-...........\hbox(3.39368+0.45404)x5.35716, shifted -1.75
-............\mathon
-............\U/msa/m/n/6 I
-............\mathoff
+...........\hbox(4.74252+0.0)x0.0, glue set - 6.96838fil
+............\glue 0.0 plus 1.0fil minus 1.0fil
+............\glue 3.08331 plus 1.54166 minus 1.02777
+............\hbox(3.88507+0.0)x3.88507, shifted -0.85745
+.............\glue 1.94254
+.............\hbox(0.0+0.0)x0.0, shifted -1.94254
+..............\pdfliteral{q }
+..............\pdfliteral{0.13725 0.2157 0.23137 RG }
+..............\pdfliteral{0.13725 0.2157 0.23137 rg }
+..............\pdfliteral{0.3985 w }
+..............\hbox(0.0+0.0)x0.0
+...............\glue 0.0
+...............\glue 0.0
+...............\glue 0.0
+...............\glue 0.0
+...............\pdfliteral{1.9353 0.0 m }
+...............\pdfliteral{-1.9353 1.9353 l }
+...............\pdfliteral{-1.9353 -1.9353 l }
+...............\pdfliteral{h }
+...............\pdfliteral{f }
+...............\glue 0.0 plus 1.0fil minus 1.0fil
+..............\pdfliteral{n }
+..............\pdfliteral{Q }
+..............\glue 0.0 plus 1.0fil minus 1.0fil
+...........\kern -1.0
 ...........\pdfcolorstack 0 pop
 ..........\pdfcolorstack 0 pop
 .........\glue 5.475
@@ -2684,20 +2741,41 @@ Completed box being shipped out [7]
 .......\glue(\parskip) 0.0
 .......\glue(\baselineskip) 3.0
 .......\hbox(6.25+0.0)x35.70605, glue set 6.25943fil, shifted 65.70016
-........\hbox(5.14368+0.0)x0.0
+........\hbox(4.74252+0.0)x0.0
 .........\glue 0.0
 .........\glue -16.42505
 .........\glue -5.475
-.........\hbox(5.14368+0.0)x16.42505, glue set 16.42505fil
+.........\hbox(4.74252+0.0)x16.42505, glue set 16.42505fil
 ..........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\hbox(5.14368+0.0)x0.0, glue set - 5.35716fil
+..........\hbox(4.74252+0.0)x0.0, glue set 1.0fil
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-...........\hbox(3.39368+0.45404)x5.35716, shifted -1.75
-............\mathon
-............\U/msa/m/n/6 I
-............\mathoff
+...........\hbox(4.74252+0.0)x0.0, glue set - 6.96838fil
+............\glue 0.0 plus 1.0fil minus 1.0fil
+............\glue 3.08331 plus 1.54166 minus 1.02777
+............\hbox(3.88507+0.0)x3.88507, shifted -0.85745
+.............\glue 1.94254
+.............\hbox(0.0+0.0)x0.0, shifted -1.94254
+..............\pdfliteral{q }
+..............\pdfliteral{0.13725 0.2157 0.23137 RG }
+..............\pdfliteral{0.13725 0.2157 0.23137 rg }
+..............\pdfliteral{0.3985 w }
+..............\hbox(0.0+0.0)x0.0
+...............\glue 0.0
+...............\glue 0.0
+...............\glue 0.0
+...............\glue 0.0
+...............\pdfliteral{1.9353 0.0 m }
+...............\pdfliteral{-1.9353 1.9353 l }
+...............\pdfliteral{-1.9353 -1.9353 l }
+...............\pdfliteral{h }
+...............\pdfliteral{f }
+...............\glue 0.0 plus 1.0fil minus 1.0fil
+..............\pdfliteral{n }
+..............\pdfliteral{Q }
+..............\glue 0.0 plus 1.0fil minus 1.0fil
+...........\kern -1.0
 ...........\pdfcolorstack 0 pop
 ..........\pdfcolorstack 0 pop
 .........\glue 5.475
@@ -2729,20 +2807,42 @@ Completed box being shipped out [7]
 .......\glue(\parskip) 0.0
 .......\glue(\baselineskip) 5.99579
 .......\hbox(7.60422+2.12914)x79.50616, glue set 28.90968fil, shifted 21.90005
-........\hbox(6.11667+0.0)x0.0
+........\hbox(5.15872+0.0)x0.0
 .........\glue 0.0
 .........\glue -16.42505
 .........\glue -5.475
-.........\hbox(6.11667+0.0)x16.42505, glue set 16.42505fil
+.........\hbox(5.15872+0.0)x16.42505, glue set 16.42505fil
 ..........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
-..........\hbox(6.11667+0.0)x0.0, glue set - 5.475fil
+..........\hbox(5.15872+0.0)x0.0, glue set 0.24335fil
 ...........\glue 0.0 plus 1.0fil minus 1.0fil
 ...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-...........\hbox(4.86667+0.0)x5.475, shifted -1.25
-............\mathon
-............\OMS/lmsy/m/n/10.95 ^^O
-............\mathoff
+...........\hbox(5.15872+0.0)x0.0, glue set - 7.15405fil
+............\glue 0.0 plus 1.0fil minus 1.0fil
+............\glue 3.65 plus 1.825 minus 1.21666
+............\hbox(3.50406+0.0)x3.50406, shifted -1.65466
+.............\glue 1.75203
+.............\hbox(0.0+0.0)x0.0, shifted -1.75203
+..............\pdfliteral{q }
+..............\pdfliteral{0.13725 0.2157 0.23137 RG }
+..............\pdfliteral{0.13725 0.2157 0.23137 rg }
+..............\pdfliteral{0.3985 w }
+..............\hbox(0.0+0.0)x0.0
+...............\glue 0.0
+...............\glue 0.0
+...............\pdfliteral{1.7455 0.0 m }
+...............\pdfliteral{1.7455 0.964 0.964 1.7455 0.0 1.7455 c }
+...............\pdfliteral{-0.964 1.7455 -1.7455 0.964 -1.7455 0.0 c }
+...............\pdfliteral{-1.7455 -0.964 -0.964 -1.7455 0.0 -1.7455 c }
+...............\pdfliteral{0.964 -1.7455 1.7455 -0.964 1.7455 0.0 c }
+...............\pdfliteral{h }
+...............\pdfliteral{0.0 0.0 m }
+...............\pdfliteral{f }
+...............\glue 0.0 plus 1.0fil minus 1.0fil
+..............\pdfliteral{n }
+..............\pdfliteral{Q }
+..............\glue 0.0 plus 1.0fil minus 1.0fil
+...........\kern -0.24335
 ...........\pdfcolorstack 0 pop
 ..........\pdfcolorstack 0 pop
 .........\glue 5.475
@@ -3273,20 +3373,42 @@ Completed box being shipped out [8]
 .....\glue(\parskip) 0.0
 .....\glue(\baselineskip) 5.99579
 .....\hbox(7.60422+2.12914)x285.38982, glue set 103.16849fil, shifted 21.90005
-......\hbox(6.11667+0.0)x0.0
+......\hbox(5.15872+0.0)x0.0
 .......\glue 0.0
 .......\glue -16.42505
 .......\glue -5.475
-.......\hbox(6.11667+0.0)x16.42505, glue set 16.42505fil
+.......\hbox(5.15872+0.0)x16.42505, glue set 16.42505fil
 ........\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
 ........\glue 0.0 plus 1.0fil minus 1.0fil
-........\hbox(6.11667+0.0)x0.0, glue set - 5.475fil
+........\hbox(5.15872+0.0)x0.0, glue set 0.24335fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 .........\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
-.........\hbox(4.86667+0.0)x5.475, shifted -1.25
-..........\mathon
-..........\OMS/lmsy/m/n/10.95 ^^O
-..........\mathoff
+.........\hbox(5.15872+0.0)x0.0, glue set - 7.15405fil
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\hbox(3.50406+0.0)x3.50406, shifted -1.65466
+...........\glue 1.75203
+...........\hbox(0.0+0.0)x0.0, shifted -1.75203
+............\pdfliteral{q }
+............\pdfliteral{0.92157 0.50587 0.10588 RG }
+............\pdfliteral{0.92157 0.50587 0.10588 rg }
+............\pdfliteral{0.3985 w }
+............\hbox(0.0+0.0)x0.0
+.............\glue 0.0
+.............\glue 0.0
+.............\pdfliteral{1.7455 0.0 m }
+.............\pdfliteral{1.7455 0.964 0.964 1.7455 0.0 1.7455 c }
+.............\pdfliteral{-0.964 1.7455 -1.7455 0.964 -1.7455 0.0 c }
+.............\pdfliteral{-1.7455 -0.964 -0.964 -1.7455 0.0 -1.7455 c }
+.............\pdfliteral{0.964 -1.7455 1.7455 -0.964 1.7455 0.0 c }
+.............\pdfliteral{h }
+.............\pdfliteral{0.0 0.0 m }
+.............\pdfliteral{f }
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfliteral{n }
+............\pdfliteral{Q }
+............\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.24335
 .........\pdfcolorstack 0 pop
 ........\pdfcolorstack 0 pop
 .......\glue 5.475
@@ -3330,20 +3452,42 @@ Completed box being shipped out [8]
 .....\glue(\parskip) 0.0
 .....\glue(\baselineskip) 3.86665
 .....\hbox(7.60422+0.0)x285.38982, glue set 122.45303fil, shifted 21.90005
-......\hbox(6.11667+0.0)x0.0
+......\hbox(5.15872+0.0)x0.0
 .......\glue 0.0
 .......\glue -16.42505
 .......\glue -5.475
-.......\hbox(6.11667+0.0)x16.42505, glue set 16.42505fil
+.......\hbox(5.15872+0.0)x16.42505, glue set 16.42505fil
 ........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ........\glue 0.0 plus 1.0fil minus 1.0fil
-........\hbox(6.11667+0.0)x0.0, glue set - 5.475fil
+........\hbox(5.15872+0.0)x0.0, glue set 0.24335fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 .........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-.........\hbox(4.86667+0.0)x5.475, shifted -1.25
-..........\mathon
-..........\OMS/lmsy/m/n/10.95 ^^O
-..........\mathoff
+.........\hbox(5.15872+0.0)x0.0, glue set - 7.15405fil
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\hbox(3.50406+0.0)x3.50406, shifted -1.65466
+...........\glue 1.75203
+...........\hbox(0.0+0.0)x0.0, shifted -1.75203
+............\pdfliteral{q }
+............\pdfliteral{0.13725 0.2157 0.23137 RG }
+............\pdfliteral{0.13725 0.2157 0.23137 rg }
+............\pdfliteral{0.3985 w }
+............\hbox(0.0+0.0)x0.0
+.............\glue 0.0
+.............\glue 0.0
+.............\pdfliteral{1.7455 0.0 m }
+.............\pdfliteral{1.7455 0.964 0.964 1.7455 0.0 1.7455 c }
+.............\pdfliteral{-0.964 1.7455 -1.7455 0.964 -1.7455 0.0 c }
+.............\pdfliteral{-1.7455 -0.964 -0.964 -1.7455 0.0 -1.7455 c }
+.............\pdfliteral{0.964 -1.7455 1.7455 -0.964 1.7455 0.0 c }
+.............\pdfliteral{h }
+.............\pdfliteral{0.0 0.0 m }
+.............\pdfliteral{f }
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfliteral{n }
+............\pdfliteral{Q }
+............\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.24335
 .........\pdfcolorstack 0 pop
 ........\pdfcolorstack 0 pop
 .......\glue 5.475
@@ -3375,20 +3519,42 @@ Completed box being shipped out [8]
 .....\glue(\parskip) 0.0
 .....\glue(\baselineskip) 5.99579
 .....\hbox(7.60422+0.0)x285.38982, glue set 112.36954fil, shifted 21.90005
-......\hbox(6.11667+0.0)x0.0
+......\hbox(5.15872+0.0)x0.0
 .......\glue 0.0
 .......\glue -16.42505
 .......\glue -5.475
-.......\hbox(6.11667+0.0)x16.42505, glue set 16.42505fil
+.......\hbox(5.15872+0.0)x16.42505, glue set 16.42505fil
 ........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ........\glue 0.0 plus 1.0fil minus 1.0fil
-........\hbox(6.11667+0.0)x0.0, glue set - 5.475fil
+........\hbox(5.15872+0.0)x0.0, glue set 0.24335fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 .........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-.........\hbox(4.86667+0.0)x5.475, shifted -1.25
-..........\mathon
-..........\OMS/lmsy/m/n/10.95 ^^O
-..........\mathoff
+.........\hbox(5.15872+0.0)x0.0, glue set - 7.15405fil
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\hbox(3.50406+0.0)x3.50406, shifted -1.65466
+...........\glue 1.75203
+...........\hbox(0.0+0.0)x0.0, shifted -1.75203
+............\pdfliteral{q }
+............\pdfliteral{0.13725 0.2157 0.23137 RG }
+............\pdfliteral{0.13725 0.2157 0.23137 rg }
+............\pdfliteral{0.3985 w }
+............\hbox(0.0+0.0)x0.0
+.............\glue 0.0
+.............\glue 0.0
+.............\pdfliteral{1.7455 0.0 m }
+.............\pdfliteral{1.7455 0.964 0.964 1.7455 0.0 1.7455 c }
+.............\pdfliteral{-0.964 1.7455 -1.7455 0.964 -1.7455 0.0 c }
+.............\pdfliteral{-1.7455 -0.964 -0.964 -1.7455 0.0 -1.7455 c }
+.............\pdfliteral{0.964 -1.7455 1.7455 -0.964 1.7455 0.0 c }
+.............\pdfliteral{h }
+.............\pdfliteral{0.0 0.0 m }
+.............\pdfliteral{f }
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfliteral{n }
+............\pdfliteral{Q }
+............\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.24335
 .........\pdfcolorstack 0 pop
 ........\pdfcolorstack 0 pop
 .......\glue 5.475
@@ -3661,20 +3827,42 @@ Completed box being shipped out [9]
 .....\glue(\parskip) 0.0
 .....\glue(\baselineskip) 5.99579
 .....\hbox(7.60422+2.12914)x285.38982, glue set 103.16849fil, shifted 21.90005
-......\hbox(6.11667+0.0)x0.0
+......\hbox(5.15872+0.0)x0.0
 .......\glue 0.0
 .......\glue -16.42505
 .......\glue -5.475
-.......\hbox(6.11667+0.0)x16.42505, glue set 16.42505fil
+.......\hbox(5.15872+0.0)x16.42505, glue set 16.42505fil
 ........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ........\glue 0.0 plus 1.0fil minus 1.0fil
-........\hbox(6.11667+0.0)x0.0, glue set - 5.475fil
+........\hbox(5.15872+0.0)x0.0, glue set 0.24335fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 .........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-.........\hbox(4.86667+0.0)x5.475, shifted -1.25
-..........\mathon
-..........\OMS/lmsy/m/n/10.95 ^^O
-..........\mathoff
+.........\hbox(5.15872+0.0)x0.0, glue set - 7.15405fil
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\hbox(3.50406+0.0)x3.50406, shifted -1.65466
+...........\glue 1.75203
+...........\hbox(0.0+0.0)x0.0, shifted -1.75203
+............\pdfliteral{q }
+............\pdfliteral{0.13725 0.2157 0.23137 RG }
+............\pdfliteral{0.13725 0.2157 0.23137 rg }
+............\pdfliteral{0.3985 w }
+............\hbox(0.0+0.0)x0.0
+.............\glue 0.0
+.............\glue 0.0
+.............\pdfliteral{1.7455 0.0 m }
+.............\pdfliteral{1.7455 0.964 0.964 1.7455 0.0 1.7455 c }
+.............\pdfliteral{-0.964 1.7455 -1.7455 0.964 -1.7455 0.0 c }
+.............\pdfliteral{-1.7455 -0.964 -0.964 -1.7455 0.0 -1.7455 c }
+.............\pdfliteral{0.964 -1.7455 1.7455 -0.964 1.7455 0.0 c }
+.............\pdfliteral{h }
+.............\pdfliteral{0.0 0.0 m }
+.............\pdfliteral{f }
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfliteral{n }
+............\pdfliteral{Q }
+............\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.24335
 .........\pdfcolorstack 0 pop
 ........\pdfcolorstack 0 pop
 .......\glue 5.475
@@ -3719,20 +3907,42 @@ Completed box being shipped out [9]
 .....\glue(\parskip) 0.0
 .....\glue(\baselineskip) 3.86665
 .....\hbox(7.60422+0.0)x285.38982, glue set 122.45303fil, shifted 21.90005
-......\hbox(6.11667+0.0)x0.0
+......\hbox(5.15872+0.0)x0.0
 .......\glue 0.0
 .......\glue -16.42505
 .......\glue -5.475
-.......\hbox(6.11667+0.0)x16.42505, glue set 16.42505fil
+.......\hbox(5.15872+0.0)x16.42505, glue set 16.42505fil
 ........\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
 ........\glue 0.0 plus 1.0fil minus 1.0fil
-........\hbox(6.11667+0.0)x0.0, glue set - 5.475fil
+........\hbox(5.15872+0.0)x0.0, glue set 0.24335fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 .........\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
-.........\hbox(4.86667+0.0)x5.475, shifted -1.25
-..........\mathon
-..........\OMS/lmsy/m/n/10.95 ^^O
-..........\mathoff
+.........\hbox(5.15872+0.0)x0.0, glue set - 7.15405fil
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\hbox(3.50406+0.0)x3.50406, shifted -1.65466
+...........\glue 1.75203
+...........\hbox(0.0+0.0)x0.0, shifted -1.75203
+............\pdfliteral{q }
+............\pdfliteral{0.92157 0.50587 0.10588 RG }
+............\pdfliteral{0.92157 0.50587 0.10588 rg }
+............\pdfliteral{0.3985 w }
+............\hbox(0.0+0.0)x0.0
+.............\glue 0.0
+.............\glue 0.0
+.............\pdfliteral{1.7455 0.0 m }
+.............\pdfliteral{1.7455 0.964 0.964 1.7455 0.0 1.7455 c }
+.............\pdfliteral{-0.964 1.7455 -1.7455 0.964 -1.7455 0.0 c }
+.............\pdfliteral{-1.7455 -0.964 -0.964 -1.7455 0.0 -1.7455 c }
+.............\pdfliteral{0.964 -1.7455 1.7455 -0.964 1.7455 0.0 c }
+.............\pdfliteral{h }
+.............\pdfliteral{0.0 0.0 m }
+.............\pdfliteral{f }
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfliteral{n }
+............\pdfliteral{Q }
+............\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.24335
 .........\pdfcolorstack 0 pop
 ........\pdfcolorstack 0 pop
 .......\glue 5.475
@@ -3765,20 +3975,42 @@ Completed box being shipped out [9]
 .....\glue(\parskip) 0.0
 .....\glue(\baselineskip) 5.99579
 .....\hbox(7.60422+0.0)x285.38982, glue set 112.36954fil, shifted 21.90005
-......\hbox(6.11667+0.0)x0.0
+......\hbox(5.15872+0.0)x0.0
 .......\glue 0.0
 .......\glue -16.42505
 .......\glue -5.475
-.......\hbox(6.11667+0.0)x16.42505, glue set 16.42505fil
+.......\hbox(5.15872+0.0)x16.42505, glue set 16.42505fil
 ........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ........\glue 0.0 plus 1.0fil minus 1.0fil
-........\hbox(6.11667+0.0)x0.0, glue set - 5.475fil
+........\hbox(5.15872+0.0)x0.0, glue set 0.24335fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 .........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-.........\hbox(4.86667+0.0)x5.475, shifted -1.25
-..........\mathon
-..........\OMS/lmsy/m/n/10.95 ^^O
-..........\mathoff
+.........\hbox(5.15872+0.0)x0.0, glue set - 7.15405fil
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\hbox(3.50406+0.0)x3.50406, shifted -1.65466
+...........\glue 1.75203
+...........\hbox(0.0+0.0)x0.0, shifted -1.75203
+............\pdfliteral{q }
+............\pdfliteral{0.13725 0.2157 0.23137 RG }
+............\pdfliteral{0.13725 0.2157 0.23137 rg }
+............\pdfliteral{0.3985 w }
+............\hbox(0.0+0.0)x0.0
+.............\glue 0.0
+.............\glue 0.0
+.............\pdfliteral{1.7455 0.0 m }
+.............\pdfliteral{1.7455 0.964 0.964 1.7455 0.0 1.7455 c }
+.............\pdfliteral{-0.964 1.7455 -1.7455 0.964 -1.7455 0.0 c }
+.............\pdfliteral{-1.7455 -0.964 -0.964 -1.7455 0.0 -1.7455 c }
+.............\pdfliteral{0.964 -1.7455 1.7455 -0.964 1.7455 0.0 c }
+.............\pdfliteral{h }
+.............\pdfliteral{0.0 0.0 m }
+.............\pdfliteral{f }
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfliteral{n }
+............\pdfliteral{Q }
+............\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.24335
 .........\pdfcolorstack 0 pop
 ........\pdfcolorstack 0 pop
 .......\glue 5.475
@@ -4051,20 +4283,42 @@ Completed box being shipped out [10]
 .....\glue(\parskip) 0.0
 .....\glue(\baselineskip) 5.99579
 .....\hbox(7.60422+2.12914)x285.38982, glue set 103.16849fil, shifted 21.90005
-......\hbox(6.11667+0.0)x0.0
+......\hbox(5.15872+0.0)x0.0
 .......\glue 0.0
 .......\glue -16.42505
 .......\glue -5.475
-.......\hbox(6.11667+0.0)x16.42505, glue set 16.42505fil
+.......\hbox(5.15872+0.0)x16.42505, glue set 16.42505fil
 ........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ........\glue 0.0 plus 1.0fil minus 1.0fil
-........\hbox(6.11667+0.0)x0.0, glue set - 5.475fil
+........\hbox(5.15872+0.0)x0.0, glue set 0.24335fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 .........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-.........\hbox(4.86667+0.0)x5.475, shifted -1.25
-..........\mathon
-..........\OMS/lmsy/m/n/10.95 ^^O
-..........\mathoff
+.........\hbox(5.15872+0.0)x0.0, glue set - 7.15405fil
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\hbox(3.50406+0.0)x3.50406, shifted -1.65466
+...........\glue 1.75203
+...........\hbox(0.0+0.0)x0.0, shifted -1.75203
+............\pdfliteral{q }
+............\pdfliteral{0.13725 0.2157 0.23137 RG }
+............\pdfliteral{0.13725 0.2157 0.23137 rg }
+............\pdfliteral{0.3985 w }
+............\hbox(0.0+0.0)x0.0
+.............\glue 0.0
+.............\glue 0.0
+.............\pdfliteral{1.7455 0.0 m }
+.............\pdfliteral{1.7455 0.964 0.964 1.7455 0.0 1.7455 c }
+.............\pdfliteral{-0.964 1.7455 -1.7455 0.964 -1.7455 0.0 c }
+.............\pdfliteral{-1.7455 -0.964 -0.964 -1.7455 0.0 -1.7455 c }
+.............\pdfliteral{0.964 -1.7455 1.7455 -0.964 1.7455 0.0 c }
+.............\pdfliteral{h }
+.............\pdfliteral{0.0 0.0 m }
+.............\pdfliteral{f }
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfliteral{n }
+............\pdfliteral{Q }
+............\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.24335
 .........\pdfcolorstack 0 pop
 ........\pdfcolorstack 0 pop
 .......\glue 5.475
@@ -4109,20 +4363,42 @@ Completed box being shipped out [10]
 .....\glue(\parskip) 0.0
 .....\glue(\baselineskip) 3.86665
 .....\hbox(7.60422+0.0)x285.38982, glue set 122.45303fil, shifted 21.90005
-......\hbox(6.11667+0.0)x0.0
+......\hbox(5.15872+0.0)x0.0
 .......\glue 0.0
 .......\glue -16.42505
 .......\glue -5.475
-.......\hbox(6.11667+0.0)x16.42505, glue set 16.42505fil
+.......\hbox(5.15872+0.0)x16.42505, glue set 16.42505fil
 ........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ........\glue 0.0 plus 1.0fil minus 1.0fil
-........\hbox(6.11667+0.0)x0.0, glue set - 5.475fil
+........\hbox(5.15872+0.0)x0.0, glue set 0.24335fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 .........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-.........\hbox(4.86667+0.0)x5.475, shifted -1.25
-..........\mathon
-..........\OMS/lmsy/m/n/10.95 ^^O
-..........\mathoff
+.........\hbox(5.15872+0.0)x0.0, glue set - 7.15405fil
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\hbox(3.50406+0.0)x3.50406, shifted -1.65466
+...........\glue 1.75203
+...........\hbox(0.0+0.0)x0.0, shifted -1.75203
+............\pdfliteral{q }
+............\pdfliteral{0.13725 0.2157 0.23137 RG }
+............\pdfliteral{0.13725 0.2157 0.23137 rg }
+............\pdfliteral{0.3985 w }
+............\hbox(0.0+0.0)x0.0
+.............\glue 0.0
+.............\glue 0.0
+.............\pdfliteral{1.7455 0.0 m }
+.............\pdfliteral{1.7455 0.964 0.964 1.7455 0.0 1.7455 c }
+.............\pdfliteral{-0.964 1.7455 -1.7455 0.964 -1.7455 0.0 c }
+.............\pdfliteral{-1.7455 -0.964 -0.964 -1.7455 0.0 -1.7455 c }
+.............\pdfliteral{0.964 -1.7455 1.7455 -0.964 1.7455 0.0 c }
+.............\pdfliteral{h }
+.............\pdfliteral{0.0 0.0 m }
+.............\pdfliteral{f }
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfliteral{n }
+............\pdfliteral{Q }
+............\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.24335
 .........\pdfcolorstack 0 pop
 ........\pdfcolorstack 0 pop
 .......\glue 5.475
@@ -4156,20 +4432,42 @@ Completed box being shipped out [10]
 .....\glue(\parskip) 0.0
 .....\glue(\baselineskip) 5.99579
 .....\hbox(7.60422+0.0)x285.38982, glue set 112.36954fil, shifted 21.90005
-......\hbox(6.11667+0.0)x0.0
+......\hbox(5.15872+0.0)x0.0
 .......\glue 0.0
 .......\glue -16.42505
 .......\glue -5.475
-.......\hbox(6.11667+0.0)x16.42505, glue set 16.42505fil
+.......\hbox(5.15872+0.0)x16.42505, glue set 16.42505fil
 ........\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
 ........\glue 0.0 plus 1.0fil minus 1.0fil
-........\hbox(6.11667+0.0)x0.0, glue set - 5.475fil
+........\hbox(5.15872+0.0)x0.0, glue set 0.24335fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 .........\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
-.........\hbox(4.86667+0.0)x5.475, shifted -1.25
-..........\mathon
-..........\OMS/lmsy/m/n/10.95 ^^O
-..........\mathoff
+.........\hbox(5.15872+0.0)x0.0, glue set - 7.15405fil
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\hbox(3.50406+0.0)x3.50406, shifted -1.65466
+...........\glue 1.75203
+...........\hbox(0.0+0.0)x0.0, shifted -1.75203
+............\pdfliteral{q }
+............\pdfliteral{0.92157 0.50587 0.10588 RG }
+............\pdfliteral{0.92157 0.50587 0.10588 rg }
+............\pdfliteral{0.3985 w }
+............\hbox(0.0+0.0)x0.0
+.............\glue 0.0
+.............\glue 0.0
+.............\pdfliteral{1.7455 0.0 m }
+.............\pdfliteral{1.7455 0.964 0.964 1.7455 0.0 1.7455 c }
+.............\pdfliteral{-0.964 1.7455 -1.7455 0.964 -1.7455 0.0 c }
+.............\pdfliteral{-1.7455 -0.964 -0.964 -1.7455 0.0 -1.7455 c }
+.............\pdfliteral{0.964 -1.7455 1.7455 -0.964 1.7455 0.0 c }
+.............\pdfliteral{h }
+.............\pdfliteral{0.0 0.0 m }
+.............\pdfliteral{f }
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfliteral{n }
+............\pdfliteral{Q }
+............\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.24335
 .........\pdfcolorstack 0 pop
 ........\pdfcolorstack 0 pop
 .......\glue 5.475
@@ -4443,20 +4741,42 @@ Completed box being shipped out [11]
 .....\glue(\parskip) 0.0
 .....\glue(\baselineskip) 5.99579
 .....\hbox(7.60422+2.12914)x285.38982, glue set 89.26804fil, shifted 21.90005
-......\hbox(6.11667+0.0)x0.0
+......\hbox(5.15872+0.0)x0.0
 .......\glue 0.0
 .......\glue -16.42505
 .......\glue -5.475
-.......\hbox(6.11667+0.0)x16.42505, glue set 16.42505fil
+.......\hbox(5.15872+0.0)x16.42505, glue set 16.42505fil
 ........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ........\glue 0.0 plus 1.0fil minus 1.0fil
-........\hbox(6.11667+0.0)x0.0, glue set - 5.475fil
+........\hbox(5.15872+0.0)x0.0, glue set 0.24335fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 .........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-.........\hbox(4.86667+0.0)x5.475, shifted -1.25
-..........\mathon
-..........\OMS/lmsy/m/n/10.95 ^^O
-..........\mathoff
+.........\hbox(5.15872+0.0)x0.0, glue set - 7.15405fil
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\hbox(3.50406+0.0)x3.50406, shifted -1.65466
+...........\glue 1.75203
+...........\hbox(0.0+0.0)x0.0, shifted -1.75203
+............\pdfliteral{q }
+............\pdfliteral{0.13725 0.2157 0.23137 RG }
+............\pdfliteral{0.13725 0.2157 0.23137 rg }
+............\pdfliteral{0.3985 w }
+............\hbox(0.0+0.0)x0.0
+.............\glue 0.0
+.............\glue 0.0
+.............\pdfliteral{1.7455 0.0 m }
+.............\pdfliteral{1.7455 0.964 0.964 1.7455 0.0 1.7455 c }
+.............\pdfliteral{-0.964 1.7455 -1.7455 0.964 -1.7455 0.0 c }
+.............\pdfliteral{-1.7455 -0.964 -0.964 -1.7455 0.0 -1.7455 c }
+.............\pdfliteral{0.964 -1.7455 1.7455 -0.964 1.7455 0.0 c }
+.............\pdfliteral{h }
+.............\pdfliteral{0.0 0.0 m }
+.............\pdfliteral{f }
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfliteral{n }
+............\pdfliteral{Q }
+............\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.24335
 .........\pdfcolorstack 0 pop
 ........\pdfcolorstack 0 pop
 .......\glue 5.475
@@ -4508,20 +4828,42 @@ Completed box being shipped out [11]
 .....\glue(\parskip) 0.0
 .....\glue(\baselineskip) 3.86665
 .....\hbox(7.60422+0.0)x285.38982, glue set 122.45303fil, shifted 21.90005
-......\hbox(6.11667+0.0)x0.0
+......\hbox(5.15872+0.0)x0.0
 .......\glue 0.0
 .......\glue -16.42505
 .......\glue -5.475
-.......\hbox(6.11667+0.0)x16.42505, glue set 16.42505fil
+.......\hbox(5.15872+0.0)x16.42505, glue set 16.42505fil
 ........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ........\glue 0.0 plus 1.0fil minus 1.0fil
-........\hbox(6.11667+0.0)x0.0, glue set - 5.475fil
+........\hbox(5.15872+0.0)x0.0, glue set 0.24335fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 .........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-.........\hbox(4.86667+0.0)x5.475, shifted -1.25
-..........\mathon
-..........\OMS/lmsy/m/n/10.95 ^^O
-..........\mathoff
+.........\hbox(5.15872+0.0)x0.0, glue set - 7.15405fil
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\hbox(3.50406+0.0)x3.50406, shifted -1.65466
+...........\glue 1.75203
+...........\hbox(0.0+0.0)x0.0, shifted -1.75203
+............\pdfliteral{q }
+............\pdfliteral{0.13725 0.2157 0.23137 RG }
+............\pdfliteral{0.13725 0.2157 0.23137 rg }
+............\pdfliteral{0.3985 w }
+............\hbox(0.0+0.0)x0.0
+.............\glue 0.0
+.............\glue 0.0
+.............\pdfliteral{1.7455 0.0 m }
+.............\pdfliteral{1.7455 0.964 0.964 1.7455 0.0 1.7455 c }
+.............\pdfliteral{-0.964 1.7455 -1.7455 0.964 -1.7455 0.0 c }
+.............\pdfliteral{-1.7455 -0.964 -0.964 -1.7455 0.0 -1.7455 c }
+.............\pdfliteral{0.964 -1.7455 1.7455 -0.964 1.7455 0.0 c }
+.............\pdfliteral{h }
+.............\pdfliteral{0.0 0.0 m }
+.............\pdfliteral{f }
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfliteral{n }
+............\pdfliteral{Q }
+............\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.24335
 .........\pdfcolorstack 0 pop
 ........\pdfcolorstack 0 pop
 .......\glue 5.475
@@ -4555,20 +4897,42 @@ Completed box being shipped out [11]
 .....\glue(\parskip) 0.0
 .....\glue(\baselineskip) 5.99579
 .....\hbox(7.60422+0.0)x285.38982, glue set 112.36954fil, shifted 21.90005
-......\hbox(6.11667+0.0)x0.0
+......\hbox(5.15872+0.0)x0.0
 .......\glue 0.0
 .......\glue -16.42505
 .......\glue -5.475
-.......\hbox(6.11667+0.0)x16.42505, glue set 16.42505fil
+.......\hbox(5.15872+0.0)x16.42505, glue set 16.42505fil
 ........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ........\glue 0.0 plus 1.0fil minus 1.0fil
-........\hbox(6.11667+0.0)x0.0, glue set - 5.475fil
+........\hbox(5.15872+0.0)x0.0, glue set 0.24335fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
 .........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-.........\hbox(4.86667+0.0)x5.475, shifted -1.25
-..........\mathon
-..........\OMS/lmsy/m/n/10.95 ^^O
-..........\mathoff
+.........\hbox(5.15872+0.0)x0.0, glue set - 7.15405fil
+..........\glue 0.0 plus 1.0fil minus 1.0fil
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\hbox(3.50406+0.0)x3.50406, shifted -1.65466
+...........\glue 1.75203
+...........\hbox(0.0+0.0)x0.0, shifted -1.75203
+............\pdfliteral{q }
+............\pdfliteral{0.13725 0.2157 0.23137 RG }
+............\pdfliteral{0.13725 0.2157 0.23137 rg }
+............\pdfliteral{0.3985 w }
+............\hbox(0.0+0.0)x0.0
+.............\glue 0.0
+.............\glue 0.0
+.............\pdfliteral{1.7455 0.0 m }
+.............\pdfliteral{1.7455 0.964 0.964 1.7455 0.0 1.7455 c }
+.............\pdfliteral{-0.964 1.7455 -1.7455 0.964 -1.7455 0.0 c }
+.............\pdfliteral{-1.7455 -0.964 -0.964 -1.7455 0.0 -1.7455 c }
+.............\pdfliteral{0.964 -1.7455 1.7455 -0.964 1.7455 0.0 c }
+.............\pdfliteral{h }
+.............\pdfliteral{0.0 0.0 m }
+.............\pdfliteral{f }
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfliteral{n }
+............\pdfliteral{Q }
+............\glue 0.0 plus 1.0fil minus 1.0fil
+.........\kern -0.24335
 .........\pdfcolorstack 0 pop
 ........\pdfcolorstack 0 pop
 .......\glue 5.475


### PR DESCRIPTION
Instead of the current behavior, where we use circle for items (which uses `$\bullet$` under the hood) and `$\blacktriangleright$` for sub-sub items, instead draw all the shapes manually. This avoids reliance on the math font, which should provide more consistent results across different engines (pdflatex, lualatex, texlatex).

This PR also changes the baseline of the bullets, trying to align each at 0.75ex.

Here's a small demo to show the state as of this PR, with a few fonts uncommented for testing:

```latex
\documentclass[16pt]{beamer}

\usepackage[T1]{fontenc}

\usetheme{moloch}

% \usepackage[semibold,light]{FiraSans}
\usepackage{lmodern}
% \usepackage{notomath}
% \usepackage{newtxtext,newtxmath}
% \usepackage[bitstream-charter]{mathdesign}

\begin{document}

\begin{frame}
  \frametitle{Lists}

  \begin{itemize}
    \item Milk
    \item Flour
          \begin{itemize}
            \item Bread
                  \begin{itemize}
                    \item Juice
                  \end{itemize}
          \end{itemize}
    \item Eggs
  \end{itemize}
\end{frame}

\end{document}
```
<img width="1027" height="715" alt="image" src="https://github.com/user-attachments/assets/c19bfc39-2116-41df-88f2-e6cae9605f7a" />

Can you please try this out, @d-e-n-n-i-s-t? Or just give me a minimal working example of what your problem was from #50 so I can test it.

Often, the triangle shapes in math fonts are not quite as sharp as this, so I'm not sure if it would be better with a more rounded shape. I don't know. I'd be happy to receive input.

Maybe you have thoughts as well, @samcarter? You're better at this stuff than me anywway.
