### PR TITLE
fix: add macro for dark/light setting for tomorrow colortheme

### DIFF
--- a/src/beamercolorthememoloch-tomorrow.dtx
+++ b/src/beamercolorthememoloch-tomorrow.dtx
@@ -39,6 +39,22 @@
 \setbeamercolor{example text}{fg=tomorrowExample}
 \setbeamercolor{progress bar}{fg=tomorrowProgress}
 
+%    \begin{macrocode}
+\renewcommand{\moloch@colors@dark}{
+  \setbeamercolor{normal text}{%
+    fg=tomorrowBackground,
+    bg=tomorrowForeground
+  }
+  \usebeamercolor[fg]{normal text}
+}
+\renewcommand{\moloch@colors@light}{
+  \setbeamercolor{normal text}{%
+    fg=tomorrowForeground,
+    bg=tomorrowBackground
+  }
+  \usebeamercolor[fg]{normal text}
+}
+%    \end{macrocode}
 %
 %    \begin{macrocode}
 \mode<all>


### PR DESCRIPTION
The very nice colortheme tomrrow so far lacked the macros for setting dark/light background. I added these to the theme, and made a minor change to the light version - by setting the normal text color explicitly again, all block fill colors etc. will be set.

I attach an MWE here to show that the original does not work and that the patch works.

Let me know if you have any questions.

```
\documentclass[10pt, aspectratio=169]{beamer}
\usepackage{graphicx}
\usetheme[sectionpage=none]{moloch}

\author{ohnemax}
\date{\today}
\title{Fixing some moloch theme tomorrow issues}

\molochset{titleformat=smallcaps}
\molochset{block=fill}
\molochset{sectionpage=simple}

\usecolortheme{moloch-tomorrow}

\begin{document}
\begin{frame}{A simple frame}
  With some text
  \begin{block}{Blocktitle}
    And a block
  \end{block}
\end{frame}

\molochset{background=dark}
\begin{frame}{An inverted frame}
  With some more text
  \begin{block}{Blocktitle}
    And a block
  \end{block}
\end{frame}

\molochset{background=light}
\begin{frame}{Back to normal}
  With the same text
  \begin{block}{Blocktitle}
    And a block
  \end{block}
\end{frame}

\begin{frame}[standout]
Also works for standout frames.
\end{frame}
\end{document}
```