### PR TITLE
fix: enable background macro for alternative color themes

### DIFF
--- a/src/beamercolorthememoloch-highcontrast.dtx
+++ b/src/beamercolorthememoloch-highcontrast.dtx
@@ -28,6 +28,15 @@
 \definecolor{mAlert}{HTML}{AD003D}
 \definecolor{mExample}{HTML}{005580}
 
+% Register high-contrast-specific light and dark color schemes
+\moloch@register@light@colors{%
+  \setbeamercolor{normal text}{fg=black,bg=white}%
+}
+
+\moloch@register@dark@colors{%
+  \setbeamercolor{normal text}{fg=white,bg=black}%
+}
+
 \setbeamercolor{normal text}{%
   fg=black,
   bg=white

--- a/src/beamercolorthememoloch-tomorrow.dtx
+++ b/src/beamercolorthememoloch-tomorrow.dtx
@@ -32,6 +32,17 @@
 \definecolor{tomorrowExample}{HTML}{4271ae}
 \definecolor{tomorrowProgress}{HTML}{8959a8}
 
+% Register tomorrow-specific light and dark color schemes
+\moloch@register@light@colors{%
+  \setbeamercolor{normal text}{fg=tomorrowForeground,bg=tomorrowBackground}%
+  \setbeamercolor{frametitle}{bg=tomorrowHeader}%
+}
+
+\moloch@register@dark@colors{%
+  \setbeamercolor{normal text}{fg=tomorrowBackground,bg=tomorrowForeground}%
+  \setbeamercolor{frametitle}{bg=tomorrowBackground}%
+}
+
 \setbeamercolor{normal text}{fg=tomorrowForeground,bg=tomorrowBackground}
 \setbeamercolor{moloch accent}{fg=tomorrowAccent}
 \setbeamercolor{frametitle}{bg=tomorrowHeader}

--- a/src/beamercolorthememoloch.dtx
+++ b/src/beamercolorthememoloch.dtx
@@ -92,24 +92,56 @@
 % |alerted text|, and |example text|.
 %
 %    \begin{macrocode}
-\newcommand{\moloch@colors@dark}{
-  \setbeamercolor{normal text}{%
-    fg=black!2,
-    bg=mDarkTeal
-  }
-  \usebeamercolor[fg]{normal text}
-}
-\newcommand{\moloch@colors@light}{
-  \setbeamercolor{normal text}{%
-    fg=mDarkTeal,
-    bg=black!2
-  }
-}
 \setbeamercolor{alerted text}{%
   fg=mLightBrown
 }
 \setbeamercolor{example text}{%
   fg=mLightGreen
+}
+%    \end{macrocode}
+
+% \subsubsection{Hooks for Color Themes}
+%
+%
+% Moloch color themes can register light and dark color schemes using the
+% commands below. The registered colors will be stored in the macros
+% |\moloch@define@light@colors| and |\moloch@define@dark@colors| respectively.
+% These macros are invoked when the |background=light| or |background=dark|
+% options are selected.
+%
+%    \begin{macrocode}
+\newcommand{\moloch@define@light@colors}{}
+\newcommand{\moloch@define@dark@colors}{}
+
+\newcommand{\moloch@register@light@colors}[1]{%
+  \renewcommand{\moloch@define@light@colors}{#1}%
+}
+
+\newcommand{\moloch@register@dark@colors}[1]{%
+  \renewcommand{\moloch@define@dark@colors}{#1}%
+}
+
+\newcommand{\moloch@colors@dark}{
+  \moloch@define@dark@colors
+  \usebeamercolor[fg]{normal text}
+}
+\newcommand{\moloch@colors@light}{
+  \moloch@define@light@colors
+  \usebeamercolor[fg]{normal text}
+}
+
+\moloch@register@light@colors{%
+  \setbeamercolor{normal text}{%
+    fg=mDarkTeal,
+    bg=black!2
+  }%
+}
+
+\moloch@register@dark@colors{%
+  \setbeamercolor{normal text}{%
+    fg=black!2,
+    bg=mDarkTeal
+  }%
 }
 %    \end{macrocode}
 %

--- a/testfiles/backgroundcolors.lvt
+++ b/testfiles/backgroundcolors.lvt
@@ -1,0 +1,4 @@
+\documentclass[hyperref={draft}]{beamer}
+\usetheme{moloch}
+\usepackage{lmodern}
+\input{backgroundcolors}

--- a/testfiles/backgroundcolors.tlg
+++ b/testfiles/backgroundcolors.tlg
@@ -1,0 +1,1311 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+Completed box being shipped out [1]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x-56.90549
+........\hbox(0.0+0.0)x0.0
+.........\hbox(265.20912+0.0)x-28.45274, shifted 265.20912
+..........\hbox(265.20912+0.0)x-28.45274
+...........\glue -28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+.........\hbox(265.20912+0.0)x335.74261, shifted 265.20912
+..........\hbox(265.20912+0.0)x335.74261
+...........\glue 307.28987
+...........\glue 28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(265.20912+0.0)x0.0, glue set 256.20912fill
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\glue 0.0 plus 1.0fill
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.0853 0.09119 0.09706 rg 0.0853 0.09119 0.09706 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\glue 2.0
+............\glue(\baselineskip) 5.0
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\pdfcolorstack 0 push {0.6455 0.64864 0.65176 rg 0.6455 0.64864 0.65176 RG}
+.............\pdfcolorstack 0 pop
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 2.0
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x-56.90549
+.........\glue -28.45274
+.........\hbox(0.0+0.0)x0.0
+..........\vbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.........\glue -28.45274
+........\glue 0.0 plus 1.0fil
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(261.20912+0.0)x307.28987
+....\pdfcolorstack 0 push {0 g 0 G}
+....\write-{}
+....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+....\glue(\topskip) 0.0
+....\vbox(261.20912+0.0)x307.28987, glue set 86.91835fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.....\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+.....\hbox(19.53326+9.7333)x307.28987, glue set - 1.0
+......\glue 0.0 minus 28.45274
+......\hbox(19.53326+9.7333)x364.19536
+.......\glue 0.0
+.......\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.......\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.......\hbox(19.53326+9.7333)x0.0, glue set - 364.19536fil
+........\rule(19.53326+9.7333)x364.19536
+........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\pdfcolorstack 0 pop
+.......\hbox(19.53326+9.7333)x364.19536
+........\kern 0.0
+........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+........\glue 0.0
+........\hbox(19.53326+9.7333)x364.19536
+.........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+.........\vbox(19.53326+9.7333)x364.19536
+..........\hbox(19.53326+9.7333)x364.19536, glue set 131.6012fil
+...........\glue(\leftskip) 8.8
+...........\hbox(0.0+0.0)x0.0
+...........\hbox(19.53326+0.0)x0.0
+............\rule(19.53326+0.0)x0.0
+...........\OT1/lmss/bx/n/12 A
+...........\glue 4.4 plus 2.19777 minus 1.46814
+...........\OT1/lmss/bx/n/12 s
+...........\OT1/lmss/bx/n/12 i
+...........\OT1/lmss/bx/n/12 m
+...........\OT1/lmss/bx/n/12 p
+...........\OT1/lmss/bx/n/12 l
+...........\OT1/lmss/bx/n/12 e
+...........\glue 4.4 plus 2.19998 minus 1.46667
+...........\OT1/lmss/bx/n/12 f
+...........\OT1/lmss/bx/n/12 r
+...........\OT1/lmss/bx/n/12 a
+...........\OT1/lmss/bx/n/12 m
+...........\OT1/lmss/bx/n/12 e
+...........\hbox(0.0+9.7333)x0.0
+............\rule(0.0+9.7333)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0 plus 1.0fil
+...........\glue(\rightskip) 8.8 plus 1.0fil
+.........\pdfcolorstack 0 pop
+........\glue 0.0
+........\pdfcolorstack 0 pop
+........\kern 0.0
+.......\pdfcolorstack 0 pop
+.......\glue 0.0
+......\glue 0.0 minus 28.45274
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 pop
+.....\glue 2.73749
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\baselineskip) 5.99579
+.....\hbox(7.60422+0.0)x307.28987, glue set 118.1795fil
+......\hbox(0.0+0.0)x0.0
+......\OT1/lmss/m/n/10.95 W
+......\OT1/lmss/m/n/10.95 i
+......\OT1/lmss/m/n/10.95 t
+......\OT1/lmss/m/n/10.95 h
+......\glue 3.65 plus 1.825 minus 1.21666
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 o
+......\OT1/lmss/m/n/10.95 m
+......\OT1/lmss/m/n/10.95 e
+......\glue 3.65 plus 1.825 minus 1.21666
+......\OT1/lmss/m/n/10.95 t
+......\OT1/lmss/m/n/10.95 e
+......\OT1/lmss/m/n/10.95 x
+......\OT1/lmss/m/n/10.95 t
+......\pdfliteral{1 0 0 1 2000.02579 2000.02579 cm }
+......\pdfliteral{1 0 0 1 -2000.02579 -2000.02579 cm }
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\glue 6.0 plus 2.0 minus 2.0
+.....\glue(\lineskip) 1.0
+.....\hbox(15.01831+0.0)x307.28987
+......\glue -3.65004
+......\pdfcolorstack 0 push {0.82275 0.82431 0.82588 rg 0.82275 0.82431 0.82588 RG}
+......\pdfcolorstack 0 push {0.82275 0.82431 0.82588 rg 0.82275 0.82431 0.82588 RG}
+......\hbox(15.01831+0.0)x0.0, glue set - 314.58995fil
+.......\rule(15.01831+0.0)x314.58995
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+......\pdfcolorstack 0 pop
+......\hbox(15.01831+0.0)x314.58995
+.......\kern 0.0
+.......\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.......\glue 3.65004
+.......\hbox(15.01831+0.0)x307.28987
+........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+........\vbox(15.01831+0.0)x307.28987
+.........\glue 3.65004
+.........\glue(\parskip) 0.0
+.........\glue(\parskip) 0.0
+.........\hbox(7.60422+0.0)x307.28987, glue set 129.44882fil
+..........\hbox(0.0+0.0)x0.0
+..........\OT1/lmss/bx/n/10.95 B
+..........\OT1/lmss/bx/n/10.95 l
+..........\OT1/lmss/bx/n/10.95 o
+..........\kern0.33458
+..........\OT1/lmss/bx/n/10.95 c
+..........\OT1/lmss/bx/n/10.95 k
+..........\OT1/lmss/bx/n/10.95 t
+..........\OT1/lmss/bx/n/10.95 i
+..........\OT1/lmss/bx/n/10.95 t
+..........\OT1/lmss/bx/n/10.95 l
+..........\OT1/lmss/bx/n/10.95 e
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 3.76405
+........\pdfcolorstack 0 pop
+.......\pdfcolorstack 0 pop
+.......\glue 3.65004
+.......\kern 0.0
+......\pdfcolorstack 0 pop
+......\glue -3.65004
+.....\glue -0.5
+.....\hbox(17.25005+0.0)x307.28987
+......\glue -3.65004
+......\pdfcolorstack 0 push {0.91138 0.91216 0.91295 rg 0.91138 0.91216 0.91295 RG}
+......\pdfcolorstack 0 push {0.91138 0.91216 0.91295 rg 0.91138 0.91216 0.91295 RG}
+......\hbox(17.25005+0.0)x0.0, glue set - 314.58995fil
+.......\rule(17.25005+0.0)x314.58995
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+......\pdfcolorstack 0 pop
+......\hbox(17.25005+0.0)x314.58995
+.......\kern 0.0
+.......\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.......\glue 3.65004
+.......\hbox(17.25005+0.0)x307.28987
+........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+........\vbox(17.25005+0.0)x307.28987
+.........\glue 3.65004
+.........\glue -3.65004
+.........\vbox(0.0+0.0)x0.0
+.........\glue(\parskip) 0.0
+.........\glue(\parskip) 0.0
+.........\glue(\baselineskip) 5.99579
+.........\hbox(7.60422+0.0)x307.28987, glue set 125.91986fil
+..........\hbox(0.0+0.0)x0.0
+..........\OT1/lmss/m/n/10.95 A
+..........\OT1/lmss/m/n/10.95 n
+..........\OT1/lmss/m/n/10.95 d
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\OT1/lmss/m/n/10.95 a
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\OT1/lmss/m/n/10.95 b
+..........\OT1/lmss/m/n/10.95 l
+..........\OT1/lmss/m/n/10.95 o
+..........\kern0.30417
+..........\OT1/lmss/m/n/10.95 c
+..........\OT1/lmss/m/n/10.95 k
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 3.65004
+........\pdfcolorstack 0 pop
+.......\pdfcolorstack 0 pop
+.......\glue 3.65004
+.......\kern 0.0
+......\pdfcolorstack 0 pop
+......\glue -3.65004
+.....\pdfliteral{1 0 0 1 2000.02579 2000.02579 cm }
+.....\pdfliteral{1 0 0 1 -2000.02579 -2000.02579 cm }
+.....\pdfliteral{1 0 0 1 2000.02579 2000.02579 cm }
+.....\pdfliteral{1 0 0 1 -2000.02579 -2000.02579 cm }
+.....\pdfliteral{1 0 0 1 2000.02579 2000.02579 cm }
+.....\pdfliteral{1 0 0 1 -2000.02579 -2000.02579 cm }
+.....\glue 3.0 plus 1.0 minus 1.0
+.....\glue 0.0 plus 1.0fil
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {0}{0}{1}{1/1}{}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {1}{1}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 4.0
+...\hbox(7.9375+0.0)x307.28987
+....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+....\hbox(7.9375+0.0)x307.28987
+.....\vbox(7.9375+0.0)x307.28987
+......\hbox(7.9375+0.0)x307.28987
+.......\hbox(7.9375+0.0)x307.28987
+........\glue -28.45274
+........\hbox(7.9375+0.0)x364.19536
+.........\vbox(7.9375+0.0)x364.19536
+..........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+..........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+..........\hbox(7.9375+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\vbox(7.9375+0.0)x364.19536
+............\hbox(3.9375+0.0)x364.19536, glue set 345.63286fill
+.............\glue(\leftskip) 4.0
+.............\hbox(0.0+0.0)x0.0
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 0.0 plus 1.0fill
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\hbox(3.9375+0.0)x9.5625, glue set 6.375fil
+..............\glue 0.0 plus 1.0fil minus 1.0fil
+..............\OT1/lmss/m/n/6 1
+.............\pdfcolorstack 0 pop
+.............\penalty 10000
+.............\glue(\parfillskip) 0.0 plus 1.0fil
+.............\glue(\rightskip) 5.0
+............\glue 4.0
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+........\glue -28.45274
+.......\glue 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fil
+......\glue(\lineskip) 0.0
+......\hbox(0.0+0.0)x0.0
+.....\glue 0.0 plus 1.0fil
+....\pdfcolorstack 0 pop
+.\kern 0.0
+.\kern 0.0
+Completed box being shipped out [2]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+...........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+...........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x-56.90549
+........\hbox(0.0+0.0)x0.0
+.........\hbox(265.20912+0.0)x-28.45274, shifted 265.20912
+..........\hbox(265.20912+0.0)x-28.45274
+...........\glue -28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+.............\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+............\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+............\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+.........\hbox(265.20912+0.0)x335.74261, shifted 265.20912
+..........\hbox(265.20912+0.0)x335.74261
+...........\glue 307.28987
+...........\glue 28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+.............\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(265.20912+0.0)x0.0, glue set 256.20912fill
+............\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+............\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+............\glue 0.0 plus 1.0fill
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.75 0.75 0.75 rg 0.75 0.75 0.75 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\glue 2.0
+............\glue(\baselineskip) 5.0
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+.............\pdfcolorstack 0 push {0.46825 0.47295 0.47765 rg 0.46825 0.47295 0.47765 RG}
+.............\pdfcolorstack 0 pop
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 2.0
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x-56.90549
+.........\glue -28.45274
+.........\hbox(0.0+0.0)x0.0
+..........\vbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+...........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.........\glue -28.45274
+........\glue 0.0 plus 1.0fil
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(261.20912+0.0)x307.28987
+....\write-{}
+....\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+....\glue(\topskip) 0.0
+....\vbox(261.20912+0.0)x307.28987, glue set 86.91835fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+.....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.....\hbox(19.53326+9.7333)x307.28987, glue set - 1.0
+......\glue 0.0 minus 28.45274
+......\hbox(19.53326+9.7333)x364.19536
+.......\glue 0.0
+.......\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+.......\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+.......\hbox(19.53326+9.7333)x0.0, glue set - 364.19536fil
+........\rule(19.53326+9.7333)x364.19536
+........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\pdfcolorstack 0 pop
+.......\hbox(19.53326+9.7333)x364.19536
+........\kern 0.0
+........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+........\glue 0.0
+........\hbox(19.53326+9.7333)x364.19536
+.........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.........\vbox(19.53326+9.7333)x364.19536
+..........\hbox(19.53326+9.7333)x364.19536, glue set 123.40657fil
+...........\glue(\leftskip) 8.8
+...........\hbox(0.0+0.0)x0.0
+...........\hbox(19.53326+0.0)x0.0
+............\rule(19.53326+0.0)x0.0
+...........\OT1/lmss/bx/n/12 A
+...........\OT1/lmss/bx/n/12 n
+...........\glue 4.4 plus 2.19998 minus 1.46667
+...........\OT1/lmss/bx/n/12 i
+...........\OT1/lmss/bx/n/12 n
+...........\OT1/lmss/bx/n/12 v
+...........\OT1/lmss/bx/n/12 e
+...........\OT1/lmss/bx/n/12 r
+...........\OT1/lmss/bx/n/12 t
+...........\OT1/lmss/bx/n/12 e
+...........\OT1/lmss/bx/n/12 d
+...........\glue 4.4 plus 2.19998 minus 1.46667
+...........\OT1/lmss/bx/n/12 f
+...........\OT1/lmss/bx/n/12 r
+...........\OT1/lmss/bx/n/12 a
+...........\OT1/lmss/bx/n/12 m
+...........\OT1/lmss/bx/n/12 e
+...........\hbox(0.0+9.7333)x0.0
+............\rule(0.0+9.7333)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0 plus 1.0fil
+...........\glue(\rightskip) 8.8 plus 1.0fil
+.........\pdfcolorstack 0 pop
+........\glue 0.0
+........\pdfcolorstack 0 pop
+........\kern 0.0
+.......\pdfcolorstack 0 pop
+.......\glue 0.0
+......\glue 0.0 minus 28.45274
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 pop
+.....\glue 2.73749
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\baselineskip) 5.99579
+.....\hbox(7.60422+0.0)x307.28987, glue set 105.11551fil
+......\hbox(0.0+0.0)x0.0
+......\OT1/lmss/m/n/10.95 W
+......\OT1/lmss/m/n/10.95 i
+......\OT1/lmss/m/n/10.95 t
+......\OT1/lmss/m/n/10.95 h
+......\glue 3.65 plus 1.825 minus 1.21666
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 o
+......\OT1/lmss/m/n/10.95 m
+......\OT1/lmss/m/n/10.95 e
+......\glue 3.65 plus 1.825 minus 1.21666
+......\OT1/lmss/m/n/10.95 m
+......\OT1/lmss/m/n/10.95 o
+......\kern-0.30418
+......\OT1/lmss/m/n/10.95 r
+......\OT1/lmss/m/n/10.95 e
+......\glue 3.65 plus 1.825 minus 1.21666
+......\OT1/lmss/m/n/10.95 t
+......\OT1/lmss/m/n/10.95 e
+......\OT1/lmss/m/n/10.95 x
+......\OT1/lmss/m/n/10.95 t
+......\pdfliteral{1 0 0 1 2000.02579 2000.02579 cm }
+......\pdfliteral{1 0 0 1 -2000.02579 -2000.02579 cm }
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\glue 6.0 plus 2.0 minus 2.0
+.....\glue(\lineskip) 1.0
+.....\hbox(15.01831+0.0)x307.28987
+......\glue -3.65004
+......\pdfcolorstack 0 push {0.29099 0.29727 0.30353 rg 0.29099 0.29727 0.30353 RG}
+......\pdfcolorstack 0 push {0.29099 0.29727 0.30353 rg 0.29099 0.29727 0.30353 RG}
+......\hbox(15.01831+0.0)x0.0, glue set - 314.58995fil
+.......\rule(15.01831+0.0)x314.58995
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+......\pdfcolorstack 0 pop
+......\hbox(15.01831+0.0)x314.58995
+.......\kern 0.0
+.......\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+.......\glue 3.65004
+.......\hbox(15.01831+0.0)x307.28987
+........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+........\vbox(15.01831+0.0)x307.28987
+.........\glue 3.65004
+.........\glue(\parskip) 0.0
+.........\glue(\parskip) 0.0
+.........\hbox(7.60422+0.0)x307.28987, glue set 129.44882fil
+..........\hbox(0.0+0.0)x0.0
+..........\OT1/lmss/bx/n/10.95 B
+..........\OT1/lmss/bx/n/10.95 l
+..........\OT1/lmss/bx/n/10.95 o
+..........\kern0.33458
+..........\OT1/lmss/bx/n/10.95 c
+..........\OT1/lmss/bx/n/10.95 k
+..........\OT1/lmss/bx/n/10.95 t
+..........\OT1/lmss/bx/n/10.95 i
+..........\OT1/lmss/bx/n/10.95 t
+..........\OT1/lmss/bx/n/10.95 l
+..........\OT1/lmss/bx/n/10.95 e
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 3.76405
+........\pdfcolorstack 0 pop
+.......\pdfcolorstack 0 pop
+.......\glue 3.65004
+.......\kern 0.0
+......\pdfcolorstack 0 pop
+......\glue -3.65004
+.....\glue -0.5
+.....\hbox(17.25005+0.0)x307.28987
+......\glue -3.65004
+......\pdfcolorstack 0 push {0.20236 0.20943 0.21648 rg 0.20236 0.20943 0.21648 RG}
+......\pdfcolorstack 0 push {0.20236 0.20943 0.21648 rg 0.20236 0.20943 0.21648 RG}
+......\hbox(17.25005+0.0)x0.0, glue set - 314.58995fil
+.......\rule(17.25005+0.0)x314.58995
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+......\pdfcolorstack 0 pop
+......\hbox(17.25005+0.0)x314.58995
+.......\kern 0.0
+.......\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+.......\glue 3.65004
+.......\hbox(17.25005+0.0)x307.28987
+........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+........\vbox(17.25005+0.0)x307.28987
+.........\glue 3.65004
+.........\glue -3.65004
+.........\vbox(0.0+0.0)x0.0
+.........\glue(\parskip) 0.0
+.........\glue(\parskip) 0.0
+.........\glue(\baselineskip) 5.99579
+.........\hbox(7.60422+0.0)x307.28987, glue set 125.91986fil
+..........\hbox(0.0+0.0)x0.0
+..........\OT1/lmss/m/n/10.95 A
+..........\OT1/lmss/m/n/10.95 n
+..........\OT1/lmss/m/n/10.95 d
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\OT1/lmss/m/n/10.95 a
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\OT1/lmss/m/n/10.95 b
+..........\OT1/lmss/m/n/10.95 l
+..........\OT1/lmss/m/n/10.95 o
+..........\kern0.30417
+..........\OT1/lmss/m/n/10.95 c
+..........\OT1/lmss/m/n/10.95 k
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 3.65004
+........\pdfcolorstack 0 pop
+.......\pdfcolorstack 0 pop
+.......\glue 3.65004
+.......\kern 0.0
+......\pdfcolorstack 0 pop
+......\glue -3.65004
+.....\pdfliteral{1 0 0 1 2000.02579 2000.02579 cm }
+.....\pdfliteral{1 0 0 1 -2000.02579 -2000.02579 cm }
+.....\pdfliteral{1 0 0 1 2000.02579 2000.02579 cm }
+.....\pdfliteral{1 0 0 1 -2000.02579 -2000.02579 cm }
+.....\pdfliteral{1 0 0 1 2000.02579 2000.02579 cm }
+.....\pdfliteral{1 0 0 1 -2000.02579 -2000.02579 cm }
+.....\glue 3.0 plus 1.0 minus 1.0
+.....\glue 0.0 plus 1.0fil
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {0}{0}{2}{2/2}{}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {2}{2}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 4.0
+...\hbox(7.9375+0.0)x307.28987
+....\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+....\hbox(7.9375+0.0)x307.28987
+.....\vbox(7.9375+0.0)x307.28987
+......\hbox(7.9375+0.0)x307.28987
+.......\hbox(7.9375+0.0)x307.28987
+........\glue -28.45274
+........\hbox(7.9375+0.0)x364.19536
+.........\vbox(7.9375+0.0)x364.19536
+..........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+..........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+..........\hbox(7.9375+0.0)x364.19536
+...........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+...........\vbox(7.9375+0.0)x364.19536
+............\hbox(3.9375+0.0)x364.19536, glue set 345.63286fill
+.............\glue(\leftskip) 4.0
+.............\hbox(0.0+0.0)x0.0
+.............\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+.............\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 0.0 plus 1.0fill
+.............\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+.............\hbox(3.9375+0.0)x9.5625, glue set 6.375fil
+..............\glue 0.0 plus 1.0fil minus 1.0fil
+..............\OT1/lmss/m/n/6 2
+.............\pdfcolorstack 0 pop
+.............\penalty 10000
+.............\glue(\parfillskip) 0.0 plus 1.0fil
+.............\glue(\rightskip) 5.0
+............\glue 4.0
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+........\glue -28.45274
+.......\glue 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fil
+......\glue(\lineskip) 0.0
+......\hbox(0.0+0.0)x0.0
+.....\glue 0.0 plus 1.0fil
+....\pdfcolorstack 0 pop
+.\kern 0.0
+Completed box being shipped out [3]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x-56.90549
+........\hbox(0.0+0.0)x0.0
+.........\hbox(265.20912+0.0)x-28.45274, shifted 265.20912
+..........\hbox(265.20912+0.0)x-28.45274
+...........\glue -28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+.........\hbox(265.20912+0.0)x335.74261, shifted 265.20912
+..........\hbox(265.20912+0.0)x335.74261
+...........\glue 307.28987
+...........\glue 28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(265.20912+0.0)x0.0, glue set 265.20912fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(265.20912+0.0)x0.0, glue set 256.20912fill
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\glue 0.0 plus 1.0fill
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.0853 0.09119 0.09706 rg 0.0853 0.09119 0.09706 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\glue 2.0
+............\glue(\baselineskip) 5.0
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\pdfcolorstack 0 push {0.6455 0.64864 0.65176 rg 0.6455 0.64864 0.65176 RG}
+.............\pdfcolorstack 0 pop
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 2.0
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x-56.90549
+.........\glue -28.45274
+.........\hbox(0.0+0.0)x0.0
+..........\vbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.........\glue -28.45274
+........\glue 0.0 plus 1.0fil
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(261.20912+0.0)x307.28987
+....\write-{}
+....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+....\glue(\topskip) 0.0
+....\vbox(261.20912+0.0)x307.28987, glue set 86.91835fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.....\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+.....\hbox(19.53326+9.7333)x307.28987, glue set - 1.0
+......\glue 0.0 minus 28.45274
+......\hbox(19.53326+9.7333)x364.19536
+.......\glue 0.0
+.......\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.......\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.......\hbox(19.53326+9.7333)x0.0, glue set - 364.19536fil
+........\rule(19.53326+9.7333)x364.19536
+........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\pdfcolorstack 0 pop
+.......\hbox(19.53326+9.7333)x364.19536
+........\kern 0.0
+........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+........\glue 0.0
+........\hbox(19.53326+9.7333)x364.19536
+.........\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+.........\vbox(19.53326+9.7333)x364.19536
+..........\hbox(19.53326+9.7333)x364.19536, glue set 130.90611fil
+...........\glue(\leftskip) 8.8
+...........\hbox(0.0+0.0)x0.0
+...........\hbox(19.53326+0.0)x0.0
+............\rule(19.53326+0.0)x0.0
+...........\OT1/lmss/bx/n/12 B
+...........\OT1/lmss/bx/n/12 a
+...........\OT1/lmss/bx/n/12 c
+...........\OT1/lmss/bx/n/12 k
+...........\glue 4.4 plus 2.19998 minus 1.46667
+...........\OT1/lmss/bx/n/12 t
+...........\OT1/lmss/bx/n/12 o
+...........\glue 4.4 plus 2.19998 minus 1.46667
+...........\OT1/lmss/bx/n/12 n
+...........\OT1/lmss/bx/n/12 o
+...........\kern-0.36667
+...........\OT1/lmss/bx/n/12 r
+...........\OT1/lmss/bx/n/12 m
+...........\OT1/lmss/bx/n/12 a
+...........\OT1/lmss/bx/n/12 l
+...........\hbox(0.0+9.7333)x0.0
+............\rule(0.0+9.7333)x0.0
+...........\penalty 10000
+...........\glue(\parfillskip) 0.0 plus 1.0fil
+...........\glue(\rightskip) 8.8 plus 1.0fil
+.........\pdfcolorstack 0 pop
+........\glue 0.0
+........\pdfcolorstack 0 pop
+........\kern 0.0
+.......\pdfcolorstack 0 pop
+.......\glue 0.0
+......\glue 0.0 minus 28.45274
+.....\pdfcolorstack 0 pop
+.....\pdfcolorstack 0 pop
+.....\glue 2.73749
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\baselineskip) 5.99579
+.....\hbox(7.60422+0.0)x307.28987, glue set 109.22186fil
+......\hbox(0.0+0.0)x0.0
+......\OT1/lmss/m/n/10.95 W
+......\OT1/lmss/m/n/10.95 i
+......\OT1/lmss/m/n/10.95 t
+......\OT1/lmss/m/n/10.95 h
+......\glue 3.65 plus 1.825 minus 1.21666
+......\OT1/lmss/m/n/10.95 t
+......\OT1/lmss/m/n/10.95 h
+......\OT1/lmss/m/n/10.95 e
+......\glue 3.65 plus 1.825 minus 1.21666
+......\OT1/lmss/m/n/10.95 s
+......\OT1/lmss/m/n/10.95 a
+......\OT1/lmss/m/n/10.95 m
+......\OT1/lmss/m/n/10.95 e
+......\glue 3.65 plus 1.825 minus 1.21666
+......\OT1/lmss/m/n/10.95 t
+......\OT1/lmss/m/n/10.95 e
+......\OT1/lmss/m/n/10.95 x
+......\OT1/lmss/m/n/10.95 t
+......\pdfliteral{1 0 0 1 2000.02579 2000.02579 cm }
+......\pdfliteral{1 0 0 1 -2000.02579 -2000.02579 cm }
+......\penalty 10000
+......\glue(\parfillskip) 0.0 plus 1.0fil
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\glue 6.0 plus 2.0 minus 2.0
+.....\glue(\lineskip) 1.0
+.....\hbox(15.01831+0.0)x307.28987
+......\glue -3.65004
+......\pdfcolorstack 0 push {0.82275 0.82431 0.82588 rg 0.82275 0.82431 0.82588 RG}
+......\pdfcolorstack 0 push {0.82275 0.82431 0.82588 rg 0.82275 0.82431 0.82588 RG}
+......\hbox(15.01831+0.0)x0.0, glue set - 314.58995fil
+.......\rule(15.01831+0.0)x314.58995
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+......\pdfcolorstack 0 pop
+......\hbox(15.01831+0.0)x314.58995
+.......\kern 0.0
+.......\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.......\glue 3.65004
+.......\hbox(15.01831+0.0)x307.28987
+........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+........\vbox(15.01831+0.0)x307.28987
+.........\glue 3.65004
+.........\glue(\parskip) 0.0
+.........\glue(\parskip) 0.0
+.........\hbox(7.60422+0.0)x307.28987, glue set 129.44882fil
+..........\hbox(0.0+0.0)x0.0
+..........\OT1/lmss/bx/n/10.95 B
+..........\OT1/lmss/bx/n/10.95 l
+..........\OT1/lmss/bx/n/10.95 o
+..........\kern0.33458
+..........\OT1/lmss/bx/n/10.95 c
+..........\OT1/lmss/bx/n/10.95 k
+..........\OT1/lmss/bx/n/10.95 t
+..........\OT1/lmss/bx/n/10.95 i
+..........\OT1/lmss/bx/n/10.95 t
+..........\OT1/lmss/bx/n/10.95 l
+..........\OT1/lmss/bx/n/10.95 e
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 3.76405
+........\pdfcolorstack 0 pop
+.......\pdfcolorstack 0 pop
+.......\glue 3.65004
+.......\kern 0.0
+......\pdfcolorstack 0 pop
+......\glue -3.65004
+.....\glue -0.5
+.....\hbox(17.25005+0.0)x307.28987
+......\glue -3.65004
+......\pdfcolorstack 0 push {0.91138 0.91216 0.91295 rg 0.91138 0.91216 0.91295 RG}
+......\pdfcolorstack 0 push {0.91138 0.91216 0.91295 rg 0.91138 0.91216 0.91295 RG}
+......\hbox(17.25005+0.0)x0.0, glue set - 314.58995fil
+.......\rule(17.25005+0.0)x314.58995
+.......\glue 0.0 plus 1.0fil minus 1.0fil
+......\pdfcolorstack 0 pop
+......\hbox(17.25005+0.0)x314.58995
+.......\kern 0.0
+.......\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.......\glue 3.65004
+.......\hbox(17.25005+0.0)x307.28987
+........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+........\vbox(17.25005+0.0)x307.28987
+.........\glue 3.65004
+.........\glue -3.65004
+.........\vbox(0.0+0.0)x0.0
+.........\glue(\parskip) 0.0
+.........\glue(\parskip) 0.0
+.........\glue(\baselineskip) 5.99579
+.........\hbox(7.60422+0.0)x307.28987, glue set 125.91986fil
+..........\hbox(0.0+0.0)x0.0
+..........\OT1/lmss/m/n/10.95 A
+..........\OT1/lmss/m/n/10.95 n
+..........\OT1/lmss/m/n/10.95 d
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\OT1/lmss/m/n/10.95 a
+..........\glue 3.65 plus 1.825 minus 1.21666
+..........\OT1/lmss/m/n/10.95 b
+..........\OT1/lmss/m/n/10.95 l
+..........\OT1/lmss/m/n/10.95 o
+..........\kern0.30417
+..........\OT1/lmss/m/n/10.95 c
+..........\OT1/lmss/m/n/10.95 k
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0 plus 1.0fil
+.........\glue 3.65004
+........\pdfcolorstack 0 pop
+.......\pdfcolorstack 0 pop
+.......\glue 3.65004
+.......\kern 0.0
+......\pdfcolorstack 0 pop
+......\glue -3.65004
+.....\pdfliteral{1 0 0 1 2000.02579 2000.02579 cm }
+.....\pdfliteral{1 0 0 1 -2000.02579 -2000.02579 cm }
+.....\pdfliteral{1 0 0 1 2000.02579 2000.02579 cm }
+.....\pdfliteral{1 0 0 1 -2000.02579 -2000.02579 cm }
+.....\pdfliteral{1 0 0 1 2000.02579 2000.02579 cm }
+.....\pdfliteral{1 0 0 1 -2000.02579 -2000.02579 cm }
+.....\glue 3.0 plus 1.0 minus 1.0
+.....\glue 0.0 plus 1.0fil
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {0}{0}{3}{3/3}{}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {3}{3}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 4.0
+...\hbox(7.9375+0.0)x307.28987
+....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+....\hbox(7.9375+0.0)x307.28987
+.....\vbox(7.9375+0.0)x307.28987
+......\hbox(7.9375+0.0)x307.28987
+.......\hbox(7.9375+0.0)x307.28987
+........\glue -28.45274
+........\hbox(7.9375+0.0)x364.19536
+.........\vbox(7.9375+0.0)x364.19536
+..........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+..........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+..........\hbox(7.9375+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\vbox(7.9375+0.0)x364.19536
+............\hbox(3.9375+0.0)x364.19536, glue set 345.63286fill
+.............\glue(\leftskip) 4.0
+.............\hbox(0.0+0.0)x0.0
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 0.0 plus 1.0fill
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\hbox(3.9375+0.0)x9.5625, glue set 6.375fil
+..............\glue 0.0 plus 1.0fil minus 1.0fil
+..............\OT1/lmss/m/n/6 3
+.............\pdfcolorstack 0 pop
+.............\penalty 10000
+.............\glue(\parfillskip) 0.0 plus 1.0fil
+.............\glue(\rightskip) 5.0
+............\glue 4.0
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+........\glue -28.45274
+.......\glue 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fil
+......\glue(\lineskip) 0.0
+......\hbox(0.0+0.0)x0.0
+.....\glue 0.0 plus 1.0fil
+....\pdfcolorstack 0 pop
+.\kern 0.0
+Completed box being shipped out [4]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x-56.90549
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x-28.45274, shifted 273.14662
+..........\hbox(273.14662+0.0)x-28.45274
+...........\glue -28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(273.14662+0.0)x0.0, glue set 273.14662fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(273.14662+0.0)x0.0, glue set 273.14662fil
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x335.74261, shifted 273.14662
+..........\hbox(273.14662+0.0)x335.74261
+...........\glue 307.28987
+...........\glue 28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(273.14662+0.0)x0.0, glue set 273.14662fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(273.14662+0.0)x0.0, glue set 264.14662fill
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\glue 0.0 plus 1.0fill
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.0853 0.09119 0.09706 rg 0.0853 0.09119 0.09706 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\glue 2.0
+............\glue(\baselineskip) 5.0
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\pdfcolorstack 0 push {0.6455 0.64864 0.65176 rg 0.6455 0.64864 0.65176 RG}
+.............\pdfcolorstack 0 pop
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 2.0
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x-56.90549
+.........\glue -28.45274
+.........\hbox(0.0+0.0)x0.0
+..........\vbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.........\glue -28.45274
+........\glue 0.0 plus 1.0fil
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(269.14662+0.0)x307.28987
+....\write-{}
+....\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+....\glue(\topskip) 0.0
+....\vbox(269.14662+0.0)x307.28987, glue set 125.57332fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\baselineskip) 7.99992
+.....\hbox(10.00008+0.0)x307.28987, glue set 48.96162fil
+......\glue(\leftskip) 0.0 plus 1.0fil
+......\hbox(0.0+0.0)x0.0
+......\OT1/lmss/bx/n/14.4 A
+......\OT1/lmss/bx/n/14.4 l
+......\OT1/lmss/bx/n/14.4 s
+......\OT1/lmss/bx/n/14.4 o
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 w
+......\kern-0.44
+......\OT1/lmss/bx/n/14.4 o
+......\kern-0.44
+......\OT1/lmss/bx/n/14.4 r
+......\OT1/lmss/bx/n/14.4 k
+......\OT1/lmss/bx/n/14.4 s
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 f
+......\OT1/lmss/bx/n/14.4 o
+......\kern-0.44
+......\OT1/lmss/bx/n/14.4 r
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 s
+......\OT1/lmss/bx/n/14.4 t
+......\OT1/lmss/bx/n/14.4 a
+......\OT1/lmss/bx/n/14.4 n
+......\OT1/lmss/bx/n/14.4 d
+......\OT1/lmss/bx/n/14.4 o
+......\OT1/lmss/bx/n/14.4 u
+......\OT1/lmss/bx/n/14.4 t
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 f
+......\OT1/lmss/bx/n/14.4 r
+......\OT1/lmss/bx/n/14.4 a
+......\OT1/lmss/bx/n/14.4 m
+......\OT1/lmss/bx/n/14.4 e
+......\OT1/lmss/bx/n/14.4 s
+......\OT1/lmss/bx/n/14.4 .
+......\penalty 10000
+......\glue(\parfillskip) 0.0
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\glue 0.0 plus 1.0fil
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {0}{0}{4}{4/4}{}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {4}{4}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 4.0
+...\hbox(0.0+0.0)x307.28987
+....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+....\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+.....\vbox(0.0+0.0)x0.0
+......\hbox(0.0+0.0)x-56.90549
+.......\hbox(0.0+0.0)x-56.90549
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\vbox(0.0+0.0)x0.0
+..........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+..........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+..........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+........\glue -28.45274
+.......\glue 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fil
+......\glue(\lineskip) 0.0
+......\hbox(0.0+0.0)x0.0
+.....\glue 0.0 plus 1.0fil
+....\pdfcolorstack 0 pop
+.\kern 0.0
+\tf@nav=\write...
+\tf@toc=\write...
+\tf@snm=\write...
+(backgroundcolors.aux)

--- a/testfiles/separation.tlg
+++ b/testfiles/separation.tlg
@@ -130,6 +130,7 @@ Completed box being shipped out [1]
 ....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ....\glue(\topskip) 0.0
 ....\vbox(261.20912+0.0)x307.28987, glue set 234.68005fill
 .....\penalty 10000

--- a/testfiles/standoutnumbering.tlg
+++ b/testfiles/standoutnumbering.tlg
@@ -129,6 +129,7 @@ Completed box being shipped out [1]
 ....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ....\pdfcolorstack 0 push {0.98 g 0.98 G}
 ....\glue(\topskip) 0.0
 ....\vbox(269.14662+0.0)x307.28987, glue set 124.81012fil

--- a/testfiles/support/backgroundcolors.tex
+++ b/testfiles/support/backgroundcolors.tex
@@ -1,0 +1,39 @@
+\input regression-test
+
+\molochset{block=fill}
+
+\usecolortheme{moloch-tomorrow}
+
+\begin{document}
+
+\START
+\showoutput
+
+\begin{frame}{A simple frame}
+  With some text
+  \begin{block}{Blocktitle}
+    And a block
+  \end{block}
+\end{frame}
+
+\molochset{background=dark}
+\begin{frame}{An inverted frame}
+  With some more text
+  \begin{block}{Blocktitle}
+    And a block
+  \end{block}
+\end{frame}
+
+\molochset{background=light}
+\begin{frame}{Back to normal}
+  With the same text
+  \begin{block}{Blocktitle}
+    And a block
+  \end{block}
+\end{frame}
+
+\begin{frame}[standout]
+  Also works for standout frames.
+\end{frame}
+
+\end{document}

--- a/testfiles/test.tlg
+++ b/testfiles/test.tlg
@@ -130,6 +130,7 @@ Completed box being shipped out [1]
 ....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+....\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ....\glue(\topskip) 0.0
 ....\vbox(261.20912+0.0)x307.28987, glue set 234.68005fill
 .....\penalty 10000


### PR DESCRIPTION
Add a macro to override the colors for dark and light versions of the theme, which can use arbitrary `\setbeamercolor` calls to setup the dark and light versions however one may choose. Thanks to @ohnemax for raising the issue and suggesting a fix in the first place.

Here's a piece of code to test out the PR (from #57 by @ohnemax):

```tex
\documentclass[10pt, aspectratio=169]{beamer}
\usepackage{graphicx}
\usetheme[sectionpage=none]{moloch}

\author{ohnemax}
\date{\today}
\title{Fixing some moloch theme tomorrow issues}

\molochset{titleformat=smallcaps}
\molochset{block=fill}
\molochset{sectionpage=simple}

\usecolortheme{moloch-tomorrow}

\begin{document}
\begin{frame}{A simple frame}
  With some text
  \begin{block}{Blocktitle}
    And a block
  \end{block}
\end{frame}

\molochset{background=dark}
\begin{frame}{An inverted frame}
  With some more text
  \begin{block}{Blocktitle}
    And a block
  \end{block}
\end{frame}

\molochset{background=light}
\begin{frame}{Back to normal}
  With the same text
  \begin{block}{Blocktitle}
    And a block
  \end{block}
\end{frame}

\begin{frame}[standout]
Also works for standout frames.
\end{frame}
\end{document}
```