### PR TITLE
feat: add customizable frametitle indent

### DIFF
--- a/src/beamerouterthememoloch.dtx
+++ b/src/beamerouterthememoloch.dtx
@@ -212,11 +212,15 @@
 \newcommand{\moloch@frametitlestrut@end}{%
   \rule[-\moloch@frametitle@padding]{0pt}{\moloch@frametitle@padding}%
 }
+
+\newlength{\moloch@frametitle@indent}
+\setlength{\moloch@frametitle@indent}{1.6ex}
+
 \defbeamertemplate{frametitle}{plain}{%
   \nointerlineskip%
   \begin{beamercolorbox}[%
       wd=\paperwidth,%
-      leftskip=1.6ex,%
+      leftskip=\moloch@frametitle@indent,%
       rightskip=\the\glueexpr 1.6ex plus 1fil\relax,%
     ]{frametitle}%
     \usebeamerfont{frametitle}%


### PR DESCRIPTION
Introduce new length \moloch@frametitle@indent to make leftskip in frametitle customizable.


This is the first time I attempt to contribute to anything related to LaTeX, so I'm not sure whether this meets any sort of standard, but it seems straightforward and works on my end.