### PR TITLE
fix: don't wrap titlepage frame in group

### DIFF
--- a/docs/implementation/beamerinnerthememoloch.md
+++ b/docs/implementation/beamerinnerthememoloch.md
@@ -175,17 +175,19 @@ default and ensure the title frame number doesn't count.
 ### `\maketitle`
 
 Inserts the title frame, or causes the current frame to use the
-`title page` template.
+`title page` template. Since we want to remove the footnote rule from
+the title page, we have to store and restore it around the call to
+`\frame`.
 
 ``` latex
 \def\maketitle{%
   \ifbeamer@inframe
     \titlepage
   \else
-    \begingroup
+    \let\beamer@saved@footnoterule\footnoterule%
     \renewcommand\footnoterule{}%
-    \frame[plain,noframenumbering]{\titlepage}
-    \endgroup
+    \frame[plain,noframenumbering]{\titlepage}%
+    \let\footnoterule\beamer@saved@footnoterule%
   \fi
 }
 ```

--- a/src/beamerinnerthememoloch.dtx
+++ b/src/beamerinnerthememoloch.dtx
@@ -186,17 +186,19 @@
 % \begin{macro}{\maketitle}
 %
 % Inserts the title frame, or causes the current frame to use the
-% \verb|title page| template.
+% \verb|title page| template. Since we want to remove the footnote rule
+% from the title page, we have to store and restore it around the call to
+% \verb|\frame|.
 %
 % \begin{macrocode}
 \def\maketitle{%
   \ifbeamer@inframe
     \titlepage
   \else
-    \begingroup
+    \let\beamer@saved@footnoterule\footnoterule%
     \renewcommand\footnoterule{}%
-    \frame[plain,noframenumbering]{\titlepage}
-    \endgroup
+    \frame[plain,noframenumbering]{\titlepage}%
+    \let\footnoterule\beamer@saved@footnoterule%
   \fi
 }
 % \end{macrocode}


### PR DESCRIPTION
Fixes #67. Wrapping the frame in the titlepage causes problems with beamer macros. Instead, store, clear, and reset the footnote rule around the frame.

Can you check if this works for you, @logological?

```latex
\documentclass{beamer}

\usetheme{moloch}

\setbeameroption{show notes}

\author{Author Name\thanks{A footnote without a rule}}

\begin{document}

\title{Foo}

\maketitle

\note{
  \begin{itemize}
    \item bar
  \end{itemize}
}

\begin{frame}[c]
  \frametitle{Something}

  A footnote that\footnote{hopefully again has a rule.}

\end{frame}

\end{document}
```

<img width="1133" height="899" alt="image" src="https://github.com/user-attachments/assets/cdd8ef12-7813-4620-a437-a5cced1b11ec" />
