### PR TITLE
feat: enable alerted and example standout styles

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,6 +16,14 @@ or image. To use it, add the key `standout` to the frame:
   Thank you!
 \end{frame}
 
+\begin{frame}[standout=alerted]
+  Important warning!
+\end{frame}
+
+\begin{frame}[standout=example]
+  Positive takeaway.
+\end{frame}
+
 \end{document}
 ```
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -641,6 +641,36 @@ Sets the background color for standout frames.
 
 :::
 
+::: {.describe-key key-name="standout alerted fg" type="<color>"
+default="theme-dependent"}
+
+Sets the foreground color for alerted standout frames (created with
+`\begin{frame}[standout=alerted]`).
+
+:::
+
+::: {.describe-key key-name="standout alerted bg" type="<color>"
+default="theme-dependent"}
+
+Sets the background color for alerted standout frames.
+
+:::
+
+::: {.describe-key key-name="standout example fg" type="<color>"
+default="theme-dependent"}
+
+Sets the foreground color for example standout frames (created with
+`\begin{frame}[standout=example]`).
+
+:::
+
+::: {.describe-key key-name="standout example bg" type="<color>"
+default="theme-dependent"}
+
+Sets the background color for example standout frames.
+
+:::
+
 #### Example: Customizing Colors Per Variant
 
 You can set different colors for light and dark variants:

--- a/src/beamercolorthememoloch.dtx
+++ b/src/beamercolorthememoloch.dtx
@@ -319,6 +319,18 @@
   \ifx\moloch@store@light@standout@bg\empty\else
     \setbeamercolor{standout}{bg=\moloch@store@light@standout@bg}%
   \fi
+  \ifx\moloch@store@light@standout@alerted@fg\empty\else
+    \setbeamercolor{standout alerted}{fg=\moloch@store@light@standout@alerted@fg}%
+  \fi
+  \ifx\moloch@store@light@standout@alerted@bg\empty\else
+    \setbeamercolor{standout alerted}{bg=\moloch@store@light@standout@alerted@bg}%
+  \fi
+  \ifx\moloch@store@light@standout@example@fg\empty\else
+    \setbeamercolor{standout example}{fg=\moloch@store@light@standout@example@fg}%
+  \fi
+  \ifx\moloch@store@light@standout@example@bg\empty\else
+    \setbeamercolor{standout example}{bg=\moloch@store@light@standout@example@bg}%
+  \fi
   \ifx\moloch@store@light@normal@text@fg\empty\else
     \setbeamercolor{normal text}{fg=\moloch@store@light@normal@text@fg}%
     \moloch@setup@text@colors
@@ -369,6 +381,18 @@
   \ifx\moloch@store@dark@standout@bg\empty\else
     \setbeamercolor{standout}{bg=\moloch@store@dark@standout@bg}%
   \fi
+  \ifx\moloch@store@dark@standout@alerted@fg\empty\else
+    \setbeamercolor{standout alerted}{fg=\moloch@store@dark@standout@alerted@fg}%
+  \fi
+  \ifx\moloch@store@dark@standout@alerted@bg\empty\else
+    \setbeamercolor{standout alerted}{bg=\moloch@store@dark@standout@alerted@bg}%
+  \fi
+  \ifx\moloch@store@dark@standout@example@fg\empty\else
+    \setbeamercolor{standout example}{fg=\moloch@store@dark@standout@example@fg}%
+  \fi
+  \ifx\moloch@store@dark@standout@example@bg\empty\else
+    \setbeamercolor{standout example}{bg=\moloch@store@dark@standout@example@bg}%
+  \fi
   \ifx\moloch@store@dark@normal@text@fg\empty\else
     \setbeamercolor{normal text}{fg=\moloch@store@dark@normal@text@fg}%
     \moloch@setup@text@colors
@@ -404,6 +428,10 @@
 %      \item \texttt{mProgressbarBg} - Progress bar background
 %      \item \texttt{mStandoutFg} - Standout frame foreground
 %      \item \texttt{mStandoutBg} - Standout frame background
+%      \item \texttt{mStandoutAlertedFg} - Alerted standout foreground
+%      \item \texttt{mStandoutAlertedBg} - Alerted standout background
+%      \item \texttt{mStandoutExampleFg} - Example standout foreground
+%      \item \texttt{mStandoutExampleBg} - Example standout background
 %      \item \texttt{mFootnoteFg} - Footnote foreground
 %    \end{itemize}
 %
@@ -423,6 +451,8 @@
   \setbeamercolor{footnote}{fg=mFootnoteFg}%
   \setbeamercolor{footnote mark}{fg=.}%
   \setbeamercolor{standout}{fg=mStandoutFg, bg=mStandoutBg}%
+  \setbeamercolor{standout alerted}{fg=mStandoutAlertedFg, bg=mStandoutAlertedBg}%
+  \setbeamercolor{standout example}{fg=mStandoutExampleFg, bg=mStandoutExampleBg}%
 }
 %    \end{macrocode}
 % \end{macro}
@@ -448,6 +478,10 @@
     \colorlet{mTitleseparatorFg}{mProgressbarFg}
     \colorlet{mStandoutFg}{mNormaltextBg}
     \colorlet{mStandoutBg}{mNormaltextFg}
+    \colorlet{mStandoutAlertedFg}{mStandoutFg}
+    \colorlet{mStandoutAlertedBg}{mAlertFg}
+    \colorlet{mStandoutExampleFg}{mStandoutFg}
+    \colorlet{mStandoutExampleBg}{mExampleFg}
     \colorlet{mFootnoteFg}{mNormaltextFg!90}
 
     \moloch@apply@semantic@colors
@@ -466,6 +500,10 @@
     \colorlet{mTitleseparatorFg}{mProgressbarFg}
     \colorlet{mStandoutFg}{mNormaltextBg}
     \colorlet{mStandoutBg}{black!15}
+    \colorlet{mStandoutAlertedFg}{mStandoutFg}
+    \colorlet{mStandoutAlertedBg}{mAlertFg}
+    \colorlet{mStandoutExampleFg}{mStandoutFg}
+    \colorlet{mStandoutExampleBg}{mExampleFg}
     \colorlet{mFootnoteFg}{mNormaltextFg!90}
 
     \moloch@apply@semantic@colors
@@ -493,6 +531,10 @@
     \definecolor{mTitleseparatorFg}{HTML}{8959a8}
     \colorlet{mStandoutFg}{white}
     \definecolor{mStandoutBg}{HTML}{1d1f21}
+    \colorlet{mStandoutAlertedFg}{mStandoutFg}
+    \colorlet{mStandoutAlertedBg}{mAlertFg}
+    \colorlet{mStandoutExampleFg}{mStandoutFg}
+    \colorlet{mStandoutExampleBg}{mExampleFg}
     \definecolor{mFootnoteFg}{HTML}{1d1f21}
 
     \moloch@apply@semantic@colors
@@ -510,6 +552,10 @@
     \definecolor{mTitleseparatorFg}{HTML}{b294bb}
     \colorlet{mStandoutFg}{white}
     \definecolor{mStandoutBg}{HTML}{1d1f21}
+    \colorlet{mStandoutAlertedFg}{mStandoutFg}
+    \colorlet{mStandoutAlertedBg}{mAlertFg}
+    \colorlet{mStandoutExampleFg}{mStandoutFg}
+    \colorlet{mStandoutExampleBg}{mExampleFg}
     \definecolor{mFootnoteFg}{HTML}{1d1f21}
 
     \moloch@apply@semantic@colors
@@ -539,6 +585,10 @@
     \definecolor{mTitleseparatorFg}{HTML}{F15854}
     \colorlet{mStandoutFg}{white}
     \colorlet{mStandoutBg}{black!60}
+    \colorlet{mStandoutAlertedFg}{mStandoutFg}
+    \colorlet{mStandoutAlertedBg}{mAlertFg}
+    \colorlet{mStandoutExampleFg}{mStandoutFg}
+    \colorlet{mStandoutExampleBg}{mExampleFg}
     \colorlet{mFootnoteFg}{black!90}
 
     \moloch@apply@semantic@colors
@@ -556,6 +606,10 @@
     \definecolor{mTitleseparatorFg}{HTML}{F15854}
     \colorlet{mStandoutFg}{white}
     \colorlet{mStandoutBg}{black!60}
+    \colorlet{mStandoutAlertedFg}{mStandoutFg}
+    \colorlet{mStandoutAlertedBg}{mAlertFg}
+    \colorlet{mStandoutExampleFg}{mStandoutFg}
+    \colorlet{mStandoutExampleBg}{mExampleFg}
     \colorlet{mFootnoteFg}{black!90}
 
     \moloch@apply@semantic@colors
@@ -588,6 +642,10 @@
     \colorlet{mTitleseparatorFg}{mAlertFg}
     \colorlet{mStandoutFg}{black}
     \colorlet{mStandoutBg}{white}
+    \colorlet{mStandoutAlertedFg}{mStandoutFg}
+    \colorlet{mStandoutAlertedBg}{mAlertFg}
+    \colorlet{mStandoutExampleFg}{mStandoutFg}
+    \colorlet{mStandoutExampleBg}{mExampleFg}
     \colorlet{mFootnoteFg}{mNormaltextFg!90}
 
     \moloch@apply@semantic@colors
@@ -608,6 +666,10 @@
     \colorlet{mTitleseparatorFg}{mAlertFg}
     \colorlet{mStandoutFg}{white}
     \colorlet{mStandoutBg}{black}
+    \colorlet{mStandoutAlertedFg}{mStandoutFg}
+    \colorlet{mStandoutAlertedBg}{mAlertFg}
+    \colorlet{mStandoutExampleFg}{mStandoutFg}
+    \colorlet{mStandoutExampleBg}{mExampleFg}
     \colorlet{mFootnoteFg}{mNormaltextFg!90}
 
     \moloch@apply@semantic@colors
@@ -638,6 +700,10 @@
     \definecolor{mTitleseparatorFg}{HTML}{40A02B}
     \definecolor{mStandoutFg}{HTML}{CAD3F5}
     \definecolor{mStandoutBg}{HTML}{303446}
+    \colorlet{mStandoutAlertedFg}{mStandoutFg}
+    \colorlet{mStandoutAlertedBg}{mAlertFg}
+    \colorlet{mStandoutExampleFg}{mStandoutFg}
+    \colorlet{mStandoutExampleBg}{mExampleFg}
     \colorlet{mFootnoteFg}{mNormaltextFg!90}
 
     \moloch@apply@semantic@colors
@@ -655,6 +721,10 @@
     \definecolor{mTitleseparatorFg}{HTML}{A6DA95}
     \definecolor{mStandoutFg}{HTML}{4C4F69}
     \definecolor{mStandoutBg}{HTML}{CCD0DA}
+    \colorlet{mStandoutAlertedFg}{mStandoutFg}
+    \colorlet{mStandoutAlertedBg}{mAlertFg}
+    \colorlet{mStandoutExampleFg}{mStandoutFg}
+    \colorlet{mStandoutExampleBg}{mExampleFg}
     \colorlet{mFootnoteFg}{mNormaltextFg!90}
 
     \moloch@apply@semantic@colors
@@ -730,6 +800,14 @@
   store/dark/standout fg/.store in=\moloch@store@dark@standout@fg,
   store/light/standout bg/.store in=\moloch@store@light@standout@bg,
   store/dark/standout bg/.store in=\moloch@store@dark@standout@bg,
+  store/light/standout alerted fg/.store in=\moloch@store@light@standout@alerted@fg,
+  store/dark/standout alerted fg/.store in=\moloch@store@dark@standout@alerted@fg,
+  store/light/standout alerted bg/.store in=\moloch@store@light@standout@alerted@bg,
+  store/dark/standout alerted bg/.store in=\moloch@store@dark@standout@alerted@bg,
+  store/light/standout example fg/.store in=\moloch@store@light@standout@example@fg,
+  store/dark/standout example fg/.store in=\moloch@store@dark@standout@example@fg,
+  store/light/standout example bg/.store in=\moloch@store@light@standout@example@bg,
+  store/dark/standout example bg/.store in=\moloch@store@dark@standout@example@bg,
   store/light/normal text fg/.store in=\moloch@store@light@normal@text@fg,
   store/dark/normal text fg/.store in=\moloch@store@dark@normal@text@fg,
   store/light/normal text bg/.store in=\moloch@store@light@normal@text@bg,
@@ -754,6 +832,14 @@
   store/dark/standout fg=,
   store/light/standout bg=,
   store/dark/standout bg=,
+  store/light/standout alerted fg=,
+  store/dark/standout alerted fg=,
+  store/light/standout alerted bg=,
+  store/dark/standout alerted bg=,
+  store/light/standout example fg=,
+  store/dark/standout example fg=,
+  store/light/standout example bg=,
+  store/dark/standout example bg=,
   store/light/normal text fg=,
   store/dark/normal text fg=,
   store/light/normal text bg=,
@@ -971,6 +1057,86 @@
       \pgfkeys{/moloch/colors/store/dark/standout bg=#1}%
       \ifmoloch@variant@dark
         \setbeamercolor{standout}{bg=#1}%
+      \fi
+    },
+  standout alerted fg/.code={%
+      \setbeamercolor{standout alerted}{fg=#1}%
+      \ifmoloch@variant@dark
+        \pgfkeys{/moloch/colors/store/dark/standout alerted fg=#1}%
+      \else
+        \pgfkeys{/moloch/colors/store/light/standout alerted fg=#1}%
+      \fi
+    },
+  light/standout alerted fg/.code={%
+      \pgfkeys{/moloch/colors/store/light/standout alerted fg=#1}%
+      \ifmoloch@variant@dark\else
+        \setbeamercolor{standout alerted}{fg=#1}%
+      \fi
+    },
+  dark/standout alerted fg/.code={%
+      \pgfkeys{/moloch/colors/store/dark/standout alerted fg=#1}%
+      \ifmoloch@variant@dark
+        \setbeamercolor{standout alerted}{fg=#1}%
+      \fi
+    },
+  standout alerted bg/.code={%
+      \setbeamercolor{standout alerted}{bg=#1}%
+      \ifmoloch@variant@dark
+        \pgfkeys{/moloch/colors/store/dark/standout alerted bg=#1}%
+      \else
+        \pgfkeys{/moloch/colors/store/light/standout alerted bg=#1}%
+      \fi
+    },
+  light/standout alerted bg/.code={%
+      \pgfkeys{/moloch/colors/store/light/standout alerted bg=#1}%
+      \ifmoloch@variant@dark\else
+        \setbeamercolor{standout alerted}{bg=#1}%
+      \fi
+    },
+  dark/standout alerted bg/.code={%
+      \pgfkeys{/moloch/colors/store/dark/standout alerted bg=#1}%
+      \ifmoloch@variant@dark
+        \setbeamercolor{standout alerted}{bg=#1}%
+      \fi
+    },
+  standout example fg/.code={%
+      \setbeamercolor{standout example}{fg=#1}%
+      \ifmoloch@variant@dark
+        \pgfkeys{/moloch/colors/store/dark/standout example fg=#1}%
+      \else
+        \pgfkeys{/moloch/colors/store/light/standout example fg=#1}%
+      \fi
+    },
+  light/standout example fg/.code={%
+      \pgfkeys{/moloch/colors/store/light/standout example fg=#1}%
+      \ifmoloch@variant@dark\else
+        \setbeamercolor{standout example}{fg=#1}%
+      \fi
+    },
+  dark/standout example fg/.code={%
+      \pgfkeys{/moloch/colors/store/dark/standout example fg=#1}%
+      \ifmoloch@variant@dark
+        \setbeamercolor{standout example}{fg=#1}%
+      \fi
+    },
+  standout example bg/.code={%
+      \setbeamercolor{standout example}{bg=#1}%
+      \ifmoloch@variant@dark
+        \pgfkeys{/moloch/colors/store/dark/standout example bg=#1}%
+      \else
+        \pgfkeys{/moloch/colors/store/light/standout example bg=#1}%
+      \fi
+    },
+  light/standout example bg/.code={%
+      \pgfkeys{/moloch/colors/store/light/standout example bg=#1}%
+      \ifmoloch@variant@dark\else
+        \setbeamercolor{standout example}{bg=#1}%
+      \fi
+    },
+  dark/standout example bg/.code={%
+      \pgfkeys{/moloch/colors/store/dark/standout example bg=#1}%
+      \ifmoloch@variant@dark
+        \setbeamercolor{standout example}{bg=#1}%
       \fi
     },
   title separator/.code={%

--- a/src/beamercolorthememoloch.dtx
+++ b/src/beamercolorthememoloch.dtx
@@ -319,6 +319,18 @@
   \ifx\moloch@store@light@standout@bg\empty\else
     \setbeamercolor{standout}{bg=\moloch@store@light@standout@bg}%
   \fi
+  \ifx\moloch@store@light@standout@alerted@fg\empty\else
+    \setbeamercolor{standout alerted}{fg=\moloch@store@light@standout@alerted@fg}%
+  \fi
+  \ifx\moloch@store@light@standout@alerted@bg\empty\else
+    \setbeamercolor{standout alerted}{bg=\moloch@store@light@standout@alerted@bg}%
+  \fi
+  \ifx\moloch@store@light@standout@example@fg\empty\else
+    \setbeamercolor{standout example}{fg=\moloch@store@light@standout@example@fg}%
+  \fi
+  \ifx\moloch@store@light@standout@example@bg\empty\else
+    \setbeamercolor{standout example}{bg=\moloch@store@light@standout@example@bg}%
+  \fi
   \ifx\moloch@store@light@normal@text@fg\empty\else
     \setbeamercolor{normal text}{fg=\moloch@store@light@normal@text@fg}%
     \moloch@setup@text@colors
@@ -369,6 +381,18 @@
   \ifx\moloch@store@dark@standout@bg\empty\else
     \setbeamercolor{standout}{bg=\moloch@store@dark@standout@bg}%
   \fi
+  \ifx\moloch@store@dark@standout@alerted@fg\empty\else
+    \setbeamercolor{standout alerted}{fg=\moloch@store@dark@standout@alerted@fg}%
+  \fi
+  \ifx\moloch@store@dark@standout@alerted@bg\empty\else
+    \setbeamercolor{standout alerted}{bg=\moloch@store@dark@standout@alerted@bg}%
+  \fi
+  \ifx\moloch@store@dark@standout@example@fg\empty\else
+    \setbeamercolor{standout example}{fg=\moloch@store@dark@standout@example@fg}%
+  \fi
+  \ifx\moloch@store@dark@standout@example@bg\empty\else
+    \setbeamercolor{standout example}{bg=\moloch@store@dark@standout@example@bg}%
+  \fi
   \ifx\moloch@store@dark@normal@text@fg\empty\else
     \setbeamercolor{normal text}{fg=\moloch@store@dark@normal@text@fg}%
     \moloch@setup@text@colors
@@ -404,6 +428,10 @@
 %      \item \texttt{mProgressbarBg} - Progress bar background
 %      \item \texttt{mStandoutFg} - Standout frame foreground
 %      \item \texttt{mStandoutBg} - Standout frame background
+%      \item \texttt{mStandoutAlertedFg} - Alerted standout foreground
+%      \item \texttt{mStandoutAlertedBg} - Alerted standout background
+%      \item \texttt{mStandoutExampleFg} - Example standout foreground
+%      \item \texttt{mStandoutExampleBg} - Example standout background
 %      \item \texttt{mFootnoteFg} - Footnote foreground
 %    \end{itemize}
 %
@@ -423,6 +451,8 @@
   \setbeamercolor{footnote}{fg=mFootnoteFg}%
   \setbeamercolor{footnote mark}{fg=.}%
   \setbeamercolor{standout}{fg=mStandoutFg, bg=mStandoutBg}%
+  \setbeamercolor{standout alerted}{fg=mStandoutAlertedFg, bg=mStandoutAlertedBg}%
+  \setbeamercolor{standout example}{fg=mStandoutExampleFg, bg=mStandoutExampleBg}%
 }
 %    \end{macrocode}
 % \end{macro}
@@ -448,6 +478,10 @@
     \colorlet{mTitleseparatorFg}{mProgressbarFg}
     \colorlet{mStandoutFg}{mNormaltextBg}
     \colorlet{mStandoutBg}{mNormaltextFg}
+    \definecolor{mStandoutAlertedFg}{HTML}{F7F0EA}
+    \definecolor{mStandoutAlertedBg}{HTML}{9E3D12}
+    \definecolor{mStandoutExampleFg}{HTML}{EAF4F3}
+    \definecolor{mStandoutExampleBg}{HTML}{0E4D4F}
     \colorlet{mFootnoteFg}{mNormaltextFg!90}
 
     \moloch@apply@semantic@colors
@@ -466,6 +500,10 @@
     \colorlet{mTitleseparatorFg}{mProgressbarFg}
     \colorlet{mStandoutFg}{mNormaltextBg}
     \colorlet{mStandoutBg}{black!15}
+    \definecolor{mStandoutAlertedFg}{HTML}{23373B}
+    \definecolor{mStandoutAlertedBg}{HTML}{F3C4A0}
+    \definecolor{mStandoutExampleFg}{HTML}{23373B}
+    \definecolor{mStandoutExampleBg}{HTML}{BFE6E2}
     \colorlet{mFootnoteFg}{mNormaltextFg!90}
 
     \moloch@apply@semantic@colors
@@ -493,6 +531,10 @@
     \definecolor{mTitleseparatorFg}{HTML}{8959a8}
     \colorlet{mStandoutFg}{white}
     \definecolor{mStandoutBg}{HTML}{1d1f21}
+    \definecolor{mStandoutAlertedFg}{HTML}{FFFFFF}
+    \definecolor{mStandoutAlertedBg}{HTML}{A63D3D}
+    \definecolor{mStandoutExampleFg}{HTML}{FFFFFF}
+    \definecolor{mStandoutExampleBg}{HTML}{2E5578}
     \definecolor{mFootnoteFg}{HTML}{1d1f21}
 
     \moloch@apply@semantic@colors
@@ -510,6 +552,10 @@
     \definecolor{mTitleseparatorFg}{HTML}{b294bb}
     \colorlet{mStandoutFg}{white}
     \definecolor{mStandoutBg}{HTML}{1d1f21}
+    \definecolor{mStandoutAlertedFg}{HTML}{1D1F21}
+    \definecolor{mStandoutAlertedBg}{HTML}{CC6666}
+    \definecolor{mStandoutExampleFg}{HTML}{1D1F21}
+    \definecolor{mStandoutExampleBg}{HTML}{81A2BE}
     \definecolor{mFootnoteFg}{HTML}{1d1f21}
 
     \moloch@apply@semantic@colors
@@ -539,6 +585,10 @@
     \definecolor{mTitleseparatorFg}{HTML}{F15854}
     \colorlet{mStandoutFg}{white}
     \colorlet{mStandoutBg}{black!60}
+    \definecolor{mStandoutAlertedFg}{HTML}{FFFFFF}
+    \definecolor{mStandoutAlertedBg}{HTML}{B01E58}
+    \definecolor{mStandoutExampleFg}{HTML}{FFFFFF}
+    \definecolor{mStandoutExampleBg}{HTML}{1E4C8A}
     \colorlet{mFootnoteFg}{black!90}
 
     \moloch@apply@semantic@colors
@@ -556,6 +606,10 @@
     \definecolor{mTitleseparatorFg}{HTML}{F15854}
     \colorlet{mStandoutFg}{white}
     \colorlet{mStandoutBg}{black!60}
+    \definecolor{mStandoutAlertedFg}{HTML}{FFFFFF}
+    \definecolor{mStandoutAlertedBg}{HTML}{E5276F}
+    \definecolor{mStandoutExampleFg}{HTML}{FFFFFF}
+    \definecolor{mStandoutExampleBg}{HTML}{265DAB}
     \colorlet{mFootnoteFg}{black!90}
 
     \moloch@apply@semantic@colors
@@ -588,6 +642,10 @@
     \colorlet{mTitleseparatorFg}{mAlertFg}
     \colorlet{mStandoutFg}{black}
     \colorlet{mStandoutBg}{white}
+    \definecolor{mStandoutAlertedFg}{HTML}{FFFFFF}
+    \definecolor{mStandoutAlertedBg}{HTML}{AD003D}
+    \definecolor{mStandoutExampleFg}{HTML}{FFFFFF}
+    \definecolor{mStandoutExampleBg}{HTML}{005580}
     \colorlet{mFootnoteFg}{mNormaltextFg!90}
 
     \moloch@apply@semantic@colors
@@ -608,6 +666,10 @@
     \colorlet{mTitleseparatorFg}{mAlertFg}
     \colorlet{mStandoutFg}{white}
     \colorlet{mStandoutBg}{black}
+    \definecolor{mStandoutAlertedFg}{HTML}{FFFFFF}
+    \definecolor{mStandoutAlertedBg}{HTML}{AD003D}
+    \definecolor{mStandoutExampleFg}{HTML}{FFFFFF}
+    \definecolor{mStandoutExampleBg}{HTML}{005580}
     \colorlet{mFootnoteFg}{mNormaltextFg!90}
 
     \moloch@apply@semantic@colors
@@ -638,6 +700,10 @@
     \definecolor{mTitleseparatorFg}{HTML}{40A02B}
     \definecolor{mStandoutFg}{HTML}{CAD3F5}
     \definecolor{mStandoutBg}{HTML}{303446}
+    \definecolor{mStandoutAlertedFg}{HTML}{EFF1F5}
+    \definecolor{mStandoutAlertedBg}{HTML}{D20F39}
+    \definecolor{mStandoutExampleFg}{HTML}{EFF1F5}
+    \definecolor{mStandoutExampleBg}{HTML}{1E66F5}
     \colorlet{mFootnoteFg}{mNormaltextFg!90}
 
     \moloch@apply@semantic@colors
@@ -655,6 +721,10 @@
     \definecolor{mTitleseparatorFg}{HTML}{A6DA95}
     \definecolor{mStandoutFg}{HTML}{4C4F69}
     \definecolor{mStandoutBg}{HTML}{CCD0DA}
+    \definecolor{mStandoutAlertedFg}{HTML}{24273A}
+    \definecolor{mStandoutAlertedBg}{HTML}{ED8796}
+    \definecolor{mStandoutExampleFg}{HTML}{24273A}
+    \definecolor{mStandoutExampleBg}{HTML}{8AADF4}
     \colorlet{mFootnoteFg}{mNormaltextFg!90}
 
     \moloch@apply@semantic@colors
@@ -730,6 +800,14 @@
   store/dark/standout fg/.store in=\moloch@store@dark@standout@fg,
   store/light/standout bg/.store in=\moloch@store@light@standout@bg,
   store/dark/standout bg/.store in=\moloch@store@dark@standout@bg,
+  store/light/standout alerted fg/.store in=\moloch@store@light@standout@alerted@fg,
+  store/dark/standout alerted fg/.store in=\moloch@store@dark@standout@alerted@fg,
+  store/light/standout alerted bg/.store in=\moloch@store@light@standout@alerted@bg,
+  store/dark/standout alerted bg/.store in=\moloch@store@dark@standout@alerted@bg,
+  store/light/standout example fg/.store in=\moloch@store@light@standout@example@fg,
+  store/dark/standout example fg/.store in=\moloch@store@dark@standout@example@fg,
+  store/light/standout example bg/.store in=\moloch@store@light@standout@example@bg,
+  store/dark/standout example bg/.store in=\moloch@store@dark@standout@example@bg,
   store/light/normal text fg/.store in=\moloch@store@light@normal@text@fg,
   store/dark/normal text fg/.store in=\moloch@store@dark@normal@text@fg,
   store/light/normal text bg/.store in=\moloch@store@light@normal@text@bg,
@@ -754,6 +832,14 @@
   store/dark/standout fg=,
   store/light/standout bg=,
   store/dark/standout bg=,
+  store/light/standout alerted fg=,
+  store/dark/standout alerted fg=,
+  store/light/standout alerted bg=,
+  store/dark/standout alerted bg=,
+  store/light/standout example fg=,
+  store/dark/standout example fg=,
+  store/light/standout example bg=,
+  store/dark/standout example bg=,
   store/light/normal text fg=,
   store/dark/normal text fg=,
   store/light/normal text bg=,
@@ -971,6 +1057,86 @@
       \pgfkeys{/moloch/colors/store/dark/standout bg=#1}%
       \ifmoloch@variant@dark
         \setbeamercolor{standout}{bg=#1}%
+      \fi
+    },
+  standout alerted fg/.code={%
+      \setbeamercolor{standout alerted}{fg=#1}%
+      \ifmoloch@variant@dark
+        \pgfkeys{/moloch/colors/store/dark/standout alerted fg=#1}%
+      \else
+        \pgfkeys{/moloch/colors/store/light/standout alerted fg=#1}%
+      \fi
+    },
+  light/standout alerted fg/.code={%
+      \pgfkeys{/moloch/colors/store/light/standout alerted fg=#1}%
+      \ifmoloch@variant@dark\else
+        \setbeamercolor{standout alerted}{fg=#1}%
+      \fi
+    },
+  dark/standout alerted fg/.code={%
+      \pgfkeys{/moloch/colors/store/dark/standout alerted fg=#1}%
+      \ifmoloch@variant@dark
+        \setbeamercolor{standout alerted}{fg=#1}%
+      \fi
+    },
+  standout alerted bg/.code={%
+      \setbeamercolor{standout alerted}{bg=#1}%
+      \ifmoloch@variant@dark
+        \pgfkeys{/moloch/colors/store/dark/standout alerted bg=#1}%
+      \else
+        \pgfkeys{/moloch/colors/store/light/standout alerted bg=#1}%
+      \fi
+    },
+  light/standout alerted bg/.code={%
+      \pgfkeys{/moloch/colors/store/light/standout alerted bg=#1}%
+      \ifmoloch@variant@dark\else
+        \setbeamercolor{standout alerted}{bg=#1}%
+      \fi
+    },
+  dark/standout alerted bg/.code={%
+      \pgfkeys{/moloch/colors/store/dark/standout alerted bg=#1}%
+      \ifmoloch@variant@dark
+        \setbeamercolor{standout alerted}{bg=#1}%
+      \fi
+    },
+  standout example fg/.code={%
+      \setbeamercolor{standout example}{fg=#1}%
+      \ifmoloch@variant@dark
+        \pgfkeys{/moloch/colors/store/dark/standout example fg=#1}%
+      \else
+        \pgfkeys{/moloch/colors/store/light/standout example fg=#1}%
+      \fi
+    },
+  light/standout example fg/.code={%
+      \pgfkeys{/moloch/colors/store/light/standout example fg=#1}%
+      \ifmoloch@variant@dark\else
+        \setbeamercolor{standout example}{fg=#1}%
+      \fi
+    },
+  dark/standout example fg/.code={%
+      \pgfkeys{/moloch/colors/store/dark/standout example fg=#1}%
+      \ifmoloch@variant@dark
+        \setbeamercolor{standout example}{fg=#1}%
+      \fi
+    },
+  standout example bg/.code={%
+      \setbeamercolor{standout example}{bg=#1}%
+      \ifmoloch@variant@dark
+        \pgfkeys{/moloch/colors/store/dark/standout example bg=#1}%
+      \else
+        \pgfkeys{/moloch/colors/store/light/standout example bg=#1}%
+      \fi
+    },
+  light/standout example bg/.code={%
+      \pgfkeys{/moloch/colors/store/light/standout example bg=#1}%
+      \ifmoloch@variant@dark\else
+        \setbeamercolor{standout example}{bg=#1}%
+      \fi
+    },
+  dark/standout example bg/.code={%
+      \pgfkeys{/moloch/colors/store/dark/standout example bg=#1}%
+      \ifmoloch@variant@dark
+        \setbeamercolor{standout example}{bg=#1}%
       \fi
     },
   title separator/.code={%

--- a/src/beamerinnerthememoloch.dtx
+++ b/src/beamerinnerthememoloch.dtx
@@ -728,30 +728,50 @@
 %
 %    \begin{macrocode}
 \providebool{moloch@standout}
+\def\moloch@standout@style@default{default}
+\def\moloch@standout@style@true{true}
+\def\moloch@standout@style@alerted{alerted}
+\def\moloch@standout@style@example{example}
+\newcommand{\moloch@set@standout@color}[1]{%
+  \def\moloch@standout@selected@style{#1}%
+  \def\moloch@standout@color{standout}%
+  \ifx\moloch@standout@selected@style\moloch@standout@style@default
+  \else\ifx\moloch@standout@selected@style\moloch@standout@style@true
+  \else\ifx\moloch@standout@selected@style\moloch@standout@style@alerted
+    \def\moloch@standout@color{standout alerted}%
+  \else\ifx\moloch@standout@selected@style\moloch@standout@style@example
+    \def\moloch@standout@color{standout example}%
+  \else
+    \PackageError{beamerinnerthememoloch}{Unknown standout style '#1'}{%
+      Use standout, standout=default, standout=alerted, or standout=example.%
+    }%
+  \fi\fi\fi\fi
+}
 \define@key{beamerframe}{standout}[true]{%
   \booltrue{moloch@standout}
   \begingroup
+  \moloch@set@standout@color{#1}%
   \setkeys{beamerframe}{c}
   \ifbool{moloch@enableStandoutNumbering}{}{%
     \setkeys{beamerframe}{noframenumbering}}
-  \ifbeamercolorempty[bg]{standout}{
+  \ifbeamercolorempty[bg]{\moloch@standout@color}{
     \setbeamercolor{background canvas}{
-      use=standout,
-      bg=-standout.fg
+      use=\moloch@standout@color,
+      bg=-\moloch@standout@color.fg
     }
   }{
     \setbeamercolor{background canvas}{
-      use=standout,
-      bg=standout.bg
+      use=\moloch@standout@color,
+      bg=\moloch@standout@color.bg
     }
   }
   \setbeamercolor{local structure}{
-    fg=standout.fg
+    fg=\moloch@standout@color.fg
   }
-  \usebeamercolor[fg]{standout}
+  \usebeamercolor[fg]{\moloch@standout@color}
   \setbeamercolor{page number in head/foot}{
-    use=standout,
-    fg=standout.fg
+    use=\moloch@standout@color,
+    fg=\moloch@standout@color.fg
   }
   \ifbool{moloch@enableStandoutFooter}{}{\setbeamertemplate{footline}{}}
 }

--- a/src/beamerinnerthememoloch.dtx
+++ b/src/beamerinnerthememoloch.dtx
@@ -750,30 +750,50 @@
 %
 %    \begin{macrocode}
 \providebool{moloch@standout}
+\def\moloch@standout@style@default{default}
+\def\moloch@standout@style@true{true}
+\def\moloch@standout@style@alerted{alerted}
+\def\moloch@standout@style@example{example}
+\newcommand{\moloch@set@standout@color}[1]{%
+  \def\moloch@standout@selected@style{#1}%
+  \def\moloch@standout@color{standout}%
+  \ifx\moloch@standout@selected@style\moloch@standout@style@default
+  \else\ifx\moloch@standout@selected@style\moloch@standout@style@true
+  \else\ifx\moloch@standout@selected@style\moloch@standout@style@alerted
+    \def\moloch@standout@color{standout alerted}%
+  \else\ifx\moloch@standout@selected@style\moloch@standout@style@example
+    \def\moloch@standout@color{standout example}%
+  \else
+    \PackageError{beamerinnerthememoloch}{Unknown standout style '#1'}{%
+      Use standout, standout=default, standout=alerted, or standout=example.%
+    }%
+  \fi\fi\fi\fi
+}
 \define@key{beamerframe}{standout}[true]{%
   \booltrue{moloch@standout}
   \begingroup
+  \moloch@set@standout@color{#1}%
   \setkeys{beamerframe}{c}
   \ifbool{moloch@enableStandoutNumbering}{}{%
     \setkeys{beamerframe}{noframenumbering}}
-  \ifbeamercolorempty[bg]{standout}{
+  \ifbeamercolorempty[bg]{\moloch@standout@color}{
     \setbeamercolor{background canvas}{
-      use=standout,
-      bg=-standout.fg
+      use=\moloch@standout@color,
+      bg=-\moloch@standout@color.fg
     }
   }{
     \setbeamercolor{background canvas}{
-      use=standout,
-      bg=standout.bg
+      use=\moloch@standout@color,
+      bg=\moloch@standout@color.bg
     }
   }
   \setbeamercolor{local structure}{
-    fg=standout.fg
+    fg=\moloch@standout@color.fg
   }
-  \usebeamercolor[fg]{standout}
+  \usebeamercolor[fg]{\moloch@standout@color}
   \setbeamercolor{page number in head/foot}{
-    use=standout,
-    fg=standout.fg
+    use=\moloch@standout@color,
+    fg=\moloch@standout@color.fg
   }
   \ifbool{moloch@enableStandoutFooter}{}{\setbeamertemplate{footline}{}}
 }

--- a/testfiles/backgroundcolors.tlg
+++ b/testfiles/backgroundcolors.tlg
@@ -1247,6 +1247,438 @@ Completed box being shipped out [4]
 .....\glue 0.0 plus 1.0fil
 ....\pdfcolorstack 0 pop
 .\kern 0.0
+Completed box being shipped out [5]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.8 0.4 0.4 rg 0.8 0.4 0.4 RG}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x-56.90549
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x-28.45274, shifted 273.14662
+..........\hbox(273.14662+0.0)x-28.45274
+...........\glue -28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(273.14662+0.0)x0.0, glue set 273.14662fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(273.14662+0.0)x0.0, glue set 273.14662fil
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x335.74261, shifted 273.14662
+..........\hbox(273.14662+0.0)x335.74261
+...........\glue 307.28987
+...........\glue 28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(273.14662+0.0)x0.0, glue set 273.14662fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(273.14662+0.0)x0.0, glue set 264.14662fill
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\glue 0.0 plus 1.0fill
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.0853 0.09119 0.09706 rg 0.0853 0.09119 0.09706 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\glue 2.0
+............\glue(\baselineskip) 5.0
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\pdfcolorstack 0 push {0.6455 0.64864 0.65176 rg 0.6455 0.64864 0.65176 RG}
+.............\pdfcolorstack 0 pop
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 2.0
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x-56.90549
+.........\glue -28.45274
+.........\hbox(0.0+0.0)x0.0
+..........\vbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.........\glue -28.45274
+........\glue 0.0 plus 1.0fil
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(269.14662+0.0)x307.28987
+....\write-{}
+....\pdfcolorstack 0 pop
+....\pdfcolorstack 0 push {1 g 1 G}
+....\glue(\topskip) 0.0
+....\vbox(269.14662+0.0)x307.28987, glue set 125.57332fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\baselineskip) 7.99992
+.....\hbox(10.00008+0.0)x307.28987, glue set 23.71194fil
+......\glue(\leftskip) 0.0 plus 1.0fil
+......\hbox(0.0+0.0)x0.0
+......\OT1/lmss/bx/n/14.4 A
+......\OT1/lmss/bx/n/14.4 l
+......\OT1/lmss/bx/n/14.4 s
+......\OT1/lmss/bx/n/14.4 o
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 w
+......\kern-0.44
+......\OT1/lmss/bx/n/14.4 o
+......\kern-0.44
+......\OT1/lmss/bx/n/14.4 r
+......\OT1/lmss/bx/n/14.4 k
+......\OT1/lmss/bx/n/14.4 s
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 f
+......\OT1/lmss/bx/n/14.4 o
+......\kern-0.44
+......\OT1/lmss/bx/n/14.4 r
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 a
+......\OT1/lmss/bx/n/14.4 l
+......\OT1/lmss/bx/n/14.4 e
+......\OT1/lmss/bx/n/14.4 r
+......\OT1/lmss/bx/n/14.4 t
+......\OT1/lmss/bx/n/14.4 e
+......\OT1/lmss/bx/n/14.4 d
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 s
+......\OT1/lmss/bx/n/14.4 t
+......\OT1/lmss/bx/n/14.4 a
+......\OT1/lmss/bx/n/14.4 n
+......\OT1/lmss/bx/n/14.4 d
+......\OT1/lmss/bx/n/14.4 o
+......\OT1/lmss/bx/n/14.4 u
+......\OT1/lmss/bx/n/14.4 t
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 f
+......\OT1/lmss/bx/n/14.4 r
+......\OT1/lmss/bx/n/14.4 a
+......\OT1/lmss/bx/n/14.4 m
+......\OT1/lmss/bx/n/14.4 e
+......\OT1/lmss/bx/n/14.4 s
+......\OT1/lmss/bx/n/14.4 .
+......\penalty 10000
+......\glue(\parfillskip) 0.0
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\glue 0.0 plus 1.0fil
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {0}{0}{5}{5/5}{}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {5}{5}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 4.0
+...\hbox(0.0+0.0)x307.28987
+....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+....\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+.....\vbox(0.0+0.0)x0.0
+......\hbox(0.0+0.0)x-56.90549
+.......\hbox(0.0+0.0)x-56.90549
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\vbox(0.0+0.0)x0.0
+..........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+..........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+..........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+........\glue -28.45274
+.......\glue 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fil
+......\glue(\lineskip) 0.0
+......\hbox(0.0+0.0)x0.0
+.....\glue 0.0 plus 1.0fil
+....\pdfcolorstack 0 pop
+.\kern 0.0
+Completed box being shipped out [6]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.25882 0.44315 0.68234 rg 0.25882 0.44315 0.68234 RG}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x-56.90549
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x-28.45274, shifted 273.14662
+..........\hbox(273.14662+0.0)x-28.45274
+...........\glue -28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(273.14662+0.0)x0.0, glue set 273.14662fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(273.14662+0.0)x0.0, glue set 273.14662fil
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x335.74261, shifted 273.14662
+..........\hbox(273.14662+0.0)x335.74261
+...........\glue 307.28987
+...........\glue 28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(273.14662+0.0)x0.0, glue set 273.14662fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(273.14662+0.0)x0.0, glue set 264.14662fill
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\glue 0.0 plus 1.0fill
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.0853 0.09119 0.09706 rg 0.0853 0.09119 0.09706 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\glue 2.0
+............\glue(\baselineskip) 5.0
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\pdfcolorstack 0 push {0.6455 0.64864 0.65176 rg 0.6455 0.64864 0.65176 RG}
+.............\pdfcolorstack 0 pop
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 2.0
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x-56.90549
+.........\glue -28.45274
+.........\hbox(0.0+0.0)x0.0
+..........\vbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.........\glue -28.45274
+........\glue 0.0 plus 1.0fil
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(269.14662+0.0)x307.28987
+....\write-{}
+....\pdfcolorstack 0 pop
+....\pdfcolorstack 0 push {1 g 1 G}
+....\glue(\topskip) 0.0
+....\vbox(269.14662+0.0)x307.28987, glue set 124.17332fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\baselineskip) 7.99992
+.....\hbox(10.00008+2.79997)x307.28987, glue set 19.46172fil
+......\glue(\leftskip) 0.0 plus 1.0fil
+......\hbox(0.0+0.0)x0.0
+......\OT1/lmss/bx/n/14.4 A
+......\OT1/lmss/bx/n/14.4 l
+......\OT1/lmss/bx/n/14.4 s
+......\OT1/lmss/bx/n/14.4 o
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 w
+......\kern-0.44
+......\OT1/lmss/bx/n/14.4 o
+......\kern-0.44
+......\OT1/lmss/bx/n/14.4 r
+......\OT1/lmss/bx/n/14.4 k
+......\OT1/lmss/bx/n/14.4 s
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 f
+......\OT1/lmss/bx/n/14.4 o
+......\kern-0.44
+......\OT1/lmss/bx/n/14.4 r
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 e
+......\OT1/lmss/bx/n/14.4 x
+......\OT1/lmss/bx/n/14.4 a
+......\OT1/lmss/bx/n/14.4 m
+......\OT1/lmss/bx/n/14.4 p
+......\OT1/lmss/bx/n/14.4 l
+......\OT1/lmss/bx/n/14.4 e
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 s
+......\OT1/lmss/bx/n/14.4 t
+......\OT1/lmss/bx/n/14.4 a
+......\OT1/lmss/bx/n/14.4 n
+......\OT1/lmss/bx/n/14.4 d
+......\OT1/lmss/bx/n/14.4 o
+......\OT1/lmss/bx/n/14.4 u
+......\OT1/lmss/bx/n/14.4 t
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 f
+......\OT1/lmss/bx/n/14.4 r
+......\OT1/lmss/bx/n/14.4 a
+......\OT1/lmss/bx/n/14.4 m
+......\OT1/lmss/bx/n/14.4 e
+......\OT1/lmss/bx/n/14.4 s
+......\OT1/lmss/bx/n/14.4 .
+......\penalty 10000
+......\glue(\parfillskip) 0.0
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\glue 0.0 plus 1.0fil
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {0}{0}{6}{6/6}{}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {6}{6}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 4.0
+...\hbox(0.0+0.0)x307.28987
+....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+....\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+.....\vbox(0.0+0.0)x0.0
+......\hbox(0.0+0.0)x-56.90549
+.......\hbox(0.0+0.0)x-56.90549
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\vbox(0.0+0.0)x0.0
+..........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+..........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+..........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+........\glue -28.45274
+.......\glue 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fil
+......\glue(\lineskip) 0.0
+......\hbox(0.0+0.0)x0.0
+.....\glue 0.0 plus 1.0fil
+....\pdfcolorstack 0 pop
+.\kern 0.0
 \tf@nav=\write...
 \tf@toc=\write...
 \tf@snm=\write...

--- a/testfiles/backgroundcolors.tlg
+++ b/testfiles/backgroundcolors.tlg
@@ -1250,6 +1250,438 @@ Completed box being shipped out [4]
 .....\glue 0.0 plus 1.0fil
 ....\pdfcolorstack 0 pop
 .\kern 0.0
+Completed box being shipped out [5]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.65099 0.23923 0.23923 rg 0.65099 0.23923 0.23923 RG}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x-56.90549
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x-28.45274, shifted 273.14662
+..........\hbox(273.14662+0.0)x-28.45274
+...........\glue -28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(273.14662+0.0)x0.0, glue set 273.14662fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(273.14662+0.0)x0.0, glue set 273.14662fil
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x335.74261, shifted 273.14662
+..........\hbox(273.14662+0.0)x335.74261
+...........\glue 307.28987
+...........\glue 28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(273.14662+0.0)x0.0, glue set 273.14662fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(273.14662+0.0)x0.0, glue set 264.14662fill
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\glue 0.0 plus 1.0fill
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.0853 0.09119 0.09706 rg 0.0853 0.09119 0.09706 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\glue 2.0
+............\glue(\baselineskip) 5.0
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\pdfcolorstack 0 push {0.6455 0.64864 0.65176 rg 0.6455 0.64864 0.65176 RG}
+.............\pdfcolorstack 0 pop
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 2.0
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x-56.90549
+.........\glue -28.45274
+.........\hbox(0.0+0.0)x0.0
+..........\vbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.........\glue -28.45274
+........\glue 0.0 plus 1.0fil
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(269.14662+0.0)x307.28987
+....\write-{}
+....\pdfcolorstack 0 pop
+....\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+....\glue(\topskip) 0.0
+....\vbox(269.14662+0.0)x307.28987, glue set 125.57332fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\baselineskip) 7.99992
+.....\hbox(10.00008+0.0)x307.28987, glue set 23.71194fil
+......\glue(\leftskip) 0.0 plus 1.0fil
+......\hbox(0.0+0.0)x0.0
+......\OT1/lmss/bx/n/14.4 A
+......\OT1/lmss/bx/n/14.4 l
+......\OT1/lmss/bx/n/14.4 s
+......\OT1/lmss/bx/n/14.4 o
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 w
+......\kern-0.44
+......\OT1/lmss/bx/n/14.4 o
+......\kern-0.44
+......\OT1/lmss/bx/n/14.4 r
+......\OT1/lmss/bx/n/14.4 k
+......\OT1/lmss/bx/n/14.4 s
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 f
+......\OT1/lmss/bx/n/14.4 o
+......\kern-0.44
+......\OT1/lmss/bx/n/14.4 r
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 a
+......\OT1/lmss/bx/n/14.4 l
+......\OT1/lmss/bx/n/14.4 e
+......\OT1/lmss/bx/n/14.4 r
+......\OT1/lmss/bx/n/14.4 t
+......\OT1/lmss/bx/n/14.4 e
+......\OT1/lmss/bx/n/14.4 d
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 s
+......\OT1/lmss/bx/n/14.4 t
+......\OT1/lmss/bx/n/14.4 a
+......\OT1/lmss/bx/n/14.4 n
+......\OT1/lmss/bx/n/14.4 d
+......\OT1/lmss/bx/n/14.4 o
+......\OT1/lmss/bx/n/14.4 u
+......\OT1/lmss/bx/n/14.4 t
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 f
+......\OT1/lmss/bx/n/14.4 r
+......\OT1/lmss/bx/n/14.4 a
+......\OT1/lmss/bx/n/14.4 m
+......\OT1/lmss/bx/n/14.4 e
+......\OT1/lmss/bx/n/14.4 s
+......\OT1/lmss/bx/n/14.4 .
+......\penalty 10000
+......\glue(\parfillskip) 0.0
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\glue 0.0 plus 1.0fil
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {0}{0}{5}{5/5}{}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {5}{5}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 4.0
+...\hbox(0.0+0.0)x307.28987
+....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+....\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+.....\vbox(0.0+0.0)x0.0
+......\hbox(0.0+0.0)x-56.90549
+.......\hbox(0.0+0.0)x-56.90549
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\vbox(0.0+0.0)x0.0
+..........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+..........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+..........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+........\glue -28.45274
+.......\glue 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fil
+......\glue(\lineskip) 0.0
+......\hbox(0.0+0.0)x0.0
+.....\glue 0.0 plus 1.0fil
+....\pdfcolorstack 0 pop
+.\kern 0.0
+Completed box being shipped out [6]
+\vbox(200.87663+0.0)x263.47263
+.\hbox(0.0+0.0)x0.0
+..\kern -72.26999
+..\vbox(0.0+0.0)x0.0, glue set 72.26999fil
+...\kern -72.26999
+...\hbox(0.0+0.0)x0.0
+....\hbox(0.0+0.0)x0.0, glue set 72.26999fil, shifted 72.26999
+.....\kern -72.26999
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+....\glue 0.0 plus 1.0fil minus 1.0fil
+...\glue 0.0 plus 1.0fil minus 1.0fil
+.\vbox(0.0+0.0)x0.0, glue set 73.27373fil
+..\kern 0.0
+..\kern -72.26999
+..\kern -1.00374
+..\hbox(0.0+0.0)x0.0, glue set 44.82098fil
+...\kern 0.0
+...\kern -43.81725
+...\kern -1.00374
+...\glue 0.0 plus 1.0fil minus 1.0fil
+..\glue 0.0 plus 1.0fil minus 1.0fil
+.\glue(\lineskip) 0.0
+.\vbox(200.87663+0.0)x263.47263
+..\glue -72.26999
+..\vbox(273.14662+0.0)x307.28987, shifted -43.81725
+...\vbox(0.0+0.0)x307.28987
+....\glue 0.0 plus 1.0fil
+....\hbox(0.0+0.0)x307.28987
+.....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.....\hbox(0.0+0.0)x307.28987
+......\vbox(0.0+0.0)x307.28987
+.......\hbox(0.0+0.0)x-28.45274
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x364.19536, shifted 273.14662
+..........\hbox(273.14662+0.0)x364.19536
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.18039 0.33333 0.4706 rg 0.18039 0.33333 0.4706 RG}
+...........\rule(273.14662+*)x364.19536
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x-56.90549
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x-28.45274, shifted 273.14662
+..........\hbox(273.14662+0.0)x-28.45274
+...........\glue -28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(273.14662+0.0)x0.0, glue set 273.14662fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(273.14662+0.0)x0.0, glue set 273.14662fil
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x0.0
+.........\hbox(273.14662+0.0)x335.74261, shifted 273.14662
+..........\hbox(273.14662+0.0)x335.74261
+...........\glue 307.28987
+...........\glue 28.45274
+...........\hbox(0.0+0.0)x0.0
+............\vbox(273.14662+0.0)x0.0, glue set 273.14662fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+............\pdfcolorstack 0 pop
+...........\vbox(273.14662+0.0)x0.0, glue set 264.14662fill
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+............\glue 0.0 plus 1.0fill
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.0853 0.09119 0.09706 rg 0.0853 0.09119 0.09706 RG}
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\glue 2.0
+............\glue(\baselineskip) 5.0
+............\hbox(0.0+0.0)x0.0, glue set - 2.84544fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+.............\pdfcolorstack 0 push {0.6455 0.64864 0.65176 rg 0.6455 0.64864 0.65176 RG}
+.............\pdfcolorstack 0 pop
+.............\pdfcolorstack 0 pop
+.............\glue 2.84544
+............\pdfcolorstack 0 pop
+............\pdfcolorstack 0 pop
+............\glue 2.0
+............\glue 0.0 plus 1.0fil
+........\hbox(0.0+0.0)x-56.90549
+.........\glue -28.45274
+.........\hbox(0.0+0.0)x0.0
+..........\vbox(0.0+0.0)x0.0
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+...........\pdfcolorstack 0 pop
+...........\pdfcolorstack 0 pop
+.........\glue -28.45274
+........\glue 0.0 plus 1.0fil
+.......\glue(\parskip) 0.0
+.......\glue(\parskip) 0.0
+.......\glue(\baselineskip) 0.0
+.......\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+........\hbox(0.0+0.0)x0.0
+........\penalty 10000
+........\glue(\parfillskip) 0.0 plus 1.0fil
+........\glue(\rightskip) 0.0
+.....\pdfcolorstack 0 pop
+...\glue 0.0
+...\glue(\lineskip) 0.0
+...\vbox(269.14662+0.0)x307.28987
+....\write-{}
+....\pdfcolorstack 0 pop
+....\pdfcolorstack 0 push {1 1 1 rg 1 1 1 RG}
+....\glue(\topskip) 0.0
+....\vbox(269.14662+0.0)x307.28987, glue set 124.17332fil
+.....\penalty 10000
+.....\vbox(0.0+0.0)x0.0
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0 plus 1.0fil
+.....\penalty 10000
+.....\penalty 10000
+.....\glue 0.0
+.....\vbox(0.0+0.0)x0.0
+.....\glue(\parskip) 0.0
+.....\glue(\parskip) 0.0
+.....\glue(\baselineskip) 7.99992
+.....\hbox(10.00008+2.79997)x307.28987, glue set 19.46172fil
+......\glue(\leftskip) 0.0 plus 1.0fil
+......\hbox(0.0+0.0)x0.0
+......\OT1/lmss/bx/n/14.4 A
+......\OT1/lmss/bx/n/14.4 l
+......\OT1/lmss/bx/n/14.4 s
+......\OT1/lmss/bx/n/14.4 o
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 w
+......\kern-0.44
+......\OT1/lmss/bx/n/14.4 o
+......\kern-0.44
+......\OT1/lmss/bx/n/14.4 r
+......\OT1/lmss/bx/n/14.4 k
+......\OT1/lmss/bx/n/14.4 s
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 f
+......\OT1/lmss/bx/n/14.4 o
+......\kern-0.44
+......\OT1/lmss/bx/n/14.4 r
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 e
+......\OT1/lmss/bx/n/14.4 x
+......\OT1/lmss/bx/n/14.4 a
+......\OT1/lmss/bx/n/14.4 m
+......\OT1/lmss/bx/n/14.4 p
+......\OT1/lmss/bx/n/14.4 l
+......\OT1/lmss/bx/n/14.4 e
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 s
+......\OT1/lmss/bx/n/14.4 t
+......\OT1/lmss/bx/n/14.4 a
+......\OT1/lmss/bx/n/14.4 n
+......\OT1/lmss/bx/n/14.4 d
+......\OT1/lmss/bx/n/14.4 o
+......\OT1/lmss/bx/n/14.4 u
+......\OT1/lmss/bx/n/14.4 t
+......\glue 5.28 plus 2.63998 minus 1.76
+......\OT1/lmss/bx/n/14.4 f
+......\OT1/lmss/bx/n/14.4 r
+......\OT1/lmss/bx/n/14.4 a
+......\OT1/lmss/bx/n/14.4 m
+......\OT1/lmss/bx/n/14.4 e
+......\OT1/lmss/bx/n/14.4 s
+......\OT1/lmss/bx/n/14.4 .
+......\penalty 10000
+......\glue(\parfillskip) 0.0
+......\glue(\rightskip) 0.0 plus 1.0fil
+.....\glue 0.0 plus 1.0fil
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \slideentry {0}{0}{6}{6/6}{}{0}}}}
+....\write1{\@writefile{nav}{\protect \headcommand {\protect \beamer@framepages {6}{6}}}}
+....\glue 0.0 plus 1.0fil
+....\glue 0.0
+...\glue(\baselineskip) 4.0
+...\hbox(0.0+0.0)x307.28987
+....\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+....\hbox(0.0+0.0)x307.28987, glue set 307.28987fil
+.....\vbox(0.0+0.0)x0.0
+......\hbox(0.0+0.0)x-56.90549
+.......\hbox(0.0+0.0)x-56.90549
+........\glue -28.45274
+........\hbox(0.0+0.0)x0.0
+.........\vbox(0.0+0.0)x0.0
+..........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+..........\pdfcolorstack 0 push {0.11374 0.12158 0.12941 rg 0.11374 0.12158 0.12941 RG}
+..........\pdfcolorstack 0 pop
+..........\pdfcolorstack 0 pop
+........\glue -28.45274
+.......\glue 0.0 plus 1.0fil
+.......\glue 0.0 plus 1.0fil
+......\glue(\lineskip) 0.0
+......\hbox(0.0+0.0)x0.0
+.....\glue 0.0 plus 1.0fil
+....\pdfcolorstack 0 pop
+.\kern 0.0
 \tf@nav=\write...
 \tf@toc=\write...
 \tf@snm=\write...

--- a/testfiles/standoutnumbering.tlg
+++ b/testfiles/standoutnumbering.tlg
@@ -236,7 +236,7 @@ Completed box being shipped out [2]
 ..........\hbox(273.14662+0.0)x364.19536
 ...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.92157 0.50587 0.10588 rg 0.92157 0.50587 0.10588 RG}
 ...........\rule(273.14662+*)x364.19536
 ...........\pdfcolorstack 0 pop
 ...........\pdfcolorstack 0 pop
@@ -446,7 +446,7 @@ Completed box being shipped out [3]
 ..........\hbox(273.14662+0.0)x364.19536
 ...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0 0.50195 0.50195 rg 0 0.50195 0.50195 RG}
 ...........\rule(273.14662+*)x364.19536
 ...........\pdfcolorstack 0 pop
 ...........\pdfcolorstack 0 pop

--- a/testfiles/standoutnumbering.tlg
+++ b/testfiles/standoutnumbering.tlg
@@ -236,7 +236,7 @@ Completed box being shipped out [2]
 ..........\hbox(273.14662+0.0)x364.19536
 ...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.61961 0.23923 0.0706 rg 0.61961 0.23923 0.0706 RG}
 ...........\rule(273.14662+*)x364.19536
 ...........\pdfcolorstack 0 pop
 ...........\pdfcolorstack 0 pop
@@ -321,7 +321,7 @@ Completed box being shipped out [2]
 ...\vbox(261.20912+0.0)x307.28987
 ....\write-{}
 ....\pdfcolorstack 0 pop
-....\pdfcolorstack 0 push {0.98 g 0.98 G}
+....\pdfcolorstack 0 push {0.96863 0.9412 0.91765 rg 0.96863 0.9412 0.91765 RG}
 ....\glue(\topskip) 0.0
 ....\vbox(261.20912+0.0)x307.28987, glue set 120.84137fil
 .....\penalty 10000
@@ -382,11 +382,11 @@ Completed box being shipped out [2]
 ............\hbox(3.9375+0.0)x364.19536, glue set 345.63286fill
 .............\glue(\leftskip) 4.0
 .............\hbox(0.0+0.0)x0.0
-.............\pdfcolorstack 0 push {0.98 g 0.98 G}
-.............\pdfcolorstack 0 push {0.98 g 0.98 G}
+.............\pdfcolorstack 0 push {0.96863 0.9412 0.91765 rg 0.96863 0.9412 0.91765 RG}
+.............\pdfcolorstack 0 push {0.96863 0.9412 0.91765 rg 0.96863 0.9412 0.91765 RG}
 .............\pdfcolorstack 0 pop
 .............\glue 0.0 plus 1.0fill
-.............\pdfcolorstack 0 push {0.98 g 0.98 G}
+.............\pdfcolorstack 0 push {0.96863 0.9412 0.91765 rg 0.96863 0.9412 0.91765 RG}
 .............\hbox(3.9375+0.0)x9.5625, glue set 6.375fil
 ..............\glue 0.0 plus 1.0fil minus 1.0fil
 ..............\OT1/lmss/m/n/6 1
@@ -446,7 +446,7 @@ Completed box being shipped out [3]
 ..........\hbox(273.14662+0.0)x364.19536
 ...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
 ...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
-...........\pdfcolorstack 0 push {0.13725 0.2157 0.23137 rg 0.13725 0.2157 0.23137 RG}
+...........\pdfcolorstack 0 push {0.0549 0.30196 0.3098 rg 0.0549 0.30196 0.3098 RG}
 ...........\rule(273.14662+*)x364.19536
 ...........\pdfcolorstack 0 pop
 ...........\pdfcolorstack 0 pop
@@ -531,7 +531,7 @@ Completed box being shipped out [3]
 ...\vbox(269.14662+0.0)x307.28987
 ....\write-{}
 ....\pdfcolorstack 0 pop
-....\pdfcolorstack 0 push {0.98 g 0.98 G}
+....\pdfcolorstack 0 push {0.91765 0.95686 0.95294 rg 0.91765 0.95686 0.95294 RG}
 ....\glue(\topskip) 0.0
 ....\vbox(269.14662+0.0)x307.28987, glue set 124.81012fil
 .....\penalty 10000

--- a/testfiles/support/backgroundcolors.tex
+++ b/testfiles/support/backgroundcolors.tex
@@ -36,4 +36,12 @@
   Also works for standout frames.
 \end{frame}
 
+\begin{frame}[standout=alerted]
+  Also works for alerted standout frames.
+\end{frame}
+
+\begin{frame}[standout=example]
+  Also works for example standout frames.
+\end{frame}
+
 \end{document}

--- a/testfiles/support/standoutnumbering.tex
+++ b/testfiles/support/standoutnumbering.tex
@@ -13,13 +13,13 @@
 
 \molochset{standoutnumbering=show}
 
-\begin{frame}[standout]
+\begin{frame}[standout=alerted]
   Hello, world!
 \end{frame}
 
 \molochset{standoutnumbering=hide}
 
-\begin{frame}[standout]
+\begin{frame}[standout=example]
   Hello, world!
 \end{frame}
 


### PR DESCRIPTION
Introduce `standout=example/alerted` for standout frames and enable separate configuration of the colors for these styles. Closes #77

This still needs to update all of the color settings for the existing themes, but otherwise, is this what you had in mind, @maikol-solis?
