### PR TITLE
feat: add `sectionpagenumbering` for section-page frame numbering

### DIFF
--- a/src/beamerinnerthememoloch.dtx
+++ b/src/beamerinnerthememoloch.dtx
@@ -114,6 +114,25 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}{sectionpagenumbering}
+%    Whether or not to number section pages. Option \verb|none| (the default)
+%    means that section pages are not numbered (do not count as frames), which
+%    matches the historical behaviour. Option \verb|show| means that they count
+%    as frames, so that the frame number is contiguous across section pages.
+%    This mirrors the \verb|standoutnumbering| option above. (Section pages are
+%    \verb|plain|, so the number is not printed on the section page itself; the
+%    effect is that subsequent frames' numbers account for the section pages.)
+%    \begin{macrocode}
+\providebool{moloch@enableSectionPageNumbering}
+\pgfkeys{
+  /moloch/inner/sectionpagenumbering/.cd,
+  .is choice,
+  none/.code={\boolfalse{moloch@enableSectionPageNumbering}},
+  show/.code={\booltrue{moloch@enableSectionPageNumbering}},
+}
+%    \end{macrocode}
+% \end{macro}
+%
 % \begin{macro}{titleseparator linewidth}
 %    Set the width of the line separating the title from the author.
 %    \begin{macrocode}
@@ -182,6 +201,7 @@
     sectionpage=progressbar,
     subsectionpage=none,
     standoutnumbering=none,
+    sectionpagenumbering=none,
     titleseparator linewidth=0.5pt,
     titlepage=moloch,
   }
@@ -538,7 +558,9 @@
     \ifbeamer@inframe
       \sectionpage
     \else
-      \frame[plain,c,noframenumbering]{\sectionpage}
+      \ifbool{moloch@enableSectionPageNumbering}
+        {\frame[plain,c]{\sectionpage}}
+        {\frame[plain,c,noframenumbering]{\sectionpage}}
     \fi
   }
 }


### PR DESCRIPTION
## Summary

Adds a `sectionpagenumbering` inner-theme option (`none` / `show`), mirroring the existing `standoutnumbering`, so section pages can optionally count as frames. Default is `none` — fully backward compatible.

## Motivation

`\moloch@enablesectionpage` hard-codes the section frame as `\frame[plain,c,noframenumbering]{\sectionpage}`, so section pages never count toward the frame number and there is no option to change that. This is asymmetric with standout pages, which already expose `standoutnumbering` (`none` / `hide` / `show`) for exactly this purpose.

Practical problem: in a deck with several sections, `\insertframenumber` ends well below the physical page count (e.g. a 21-page deck shows a max frame number of 14 because the section pages and standout are excluded). Users who number by frame and want the number to reflect the deck's real length currently have to use `\insertpagenumber` in a custom footer or re-implement `\AtBeginSection` themselves.

## Usage

```latex
\molochset{sectionpagenumbering=show}   % or none (default)
% equivalently: \usetheme[sectionpagenumbering=show]{moloch}
```

- `none` (default): section pages are not numbered (current behaviour).
- `show`: section pages count as frames, so numbering is contiguous across them. (Section pages are `plain`, so no number is printed *on* the section page; the effect is that later frames' numbers account for them.)

## Testing

TeX Live 2024: docstrip regenerates the `.sty` cleanly. With `sectionpagenumbering=show`, a two-section test deck reports frame numbers `f2, f4` on its content frames (section pages consume `f1, f3`); with the default, behaviour is unchanged.

## Possible extension

The same pattern could be applied to subsection pages (`subsectionpagenumbering`) for full symmetry — happy to extend if wanted.

---

_Disclaimer: this change was produced by vibe coding with Claude Opus 4.8._
